### PR TITLE
Only respect ZIP64 fields if they're at max size

### DIFF
--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -135,10 +135,14 @@ fn get_combined_sizes(
 
     if let Some(extra_field) = extra_field {
         if let Some(s) = extra_field.uncompressed_size {
-            uncompressed_size = s;
+            if uncompressed_size == NON_ZIP64_MAX_SIZE as u64 {
+                uncompressed_size = s;
+            }
         }
         if let Some(s) = extra_field.compressed_size {
-            compressed_size = s;
+            if compressed_size == NON_ZIP64_MAX_SIZE as u64 {
+                compressed_size = s;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Per the [spec](https://pkwaredownloads.blob.core.windows.net/pkware-general/Documentation/APPNOTE-6.3.9.TXT):

> If an archive is in ZIP64 format and the value in this field is 0xFFFFFFFF, the size will be in the corresponding 8 byte ZIP64 extended information extra field.
