### PR TITLE
Reject duplicate extra field headers

### DIFF
--- a/src/base/read/stream.rs
+++ b/src/base/read/stream.rs
@@ -46,14 +46,14 @@
 //! # }
 //! ```
 
-use crate::base::read::io::entry::ZipEntryReader;
-use crate::error::Result;
-use crate::error::ZipError;
 use std::io;
 use std::io::Read;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::base::read::io::entry::ZipEntryReader;
+use crate::error::Result;
+use crate::error::ZipError;
 use crate::spec::consts::DATA_DESCRIPTOR_LENGTH;
 use crate::spec::consts::DATA_DESCRIPTOR_SIGNATURE;
 use crate::spec::consts::SIGNATURE_LENGTH;

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -81,7 +81,6 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                 writer.is_zip64 = true;
             }
             entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformationExtraField {
-                header_id: HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
                 uncompressed_size: Some(entry.uncompressed_size),
                 compressed_size: Some(entry.compressed_size),
                 relative_header_offset: None,
@@ -190,7 +189,6 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
                 None => {
                     self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(
                         Zip64ExtendedInformationExtraField {
-                            header_id: HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
                             uncompressed_size: Some(uncompressed_size),
                             compressed_size: Some(compressed_size),
                             relative_header_offset: Some(self.lfh_offset),

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -158,7 +158,7 @@ impl ZipEntry {
     pub fn dir(&self) -> Result<bool> {
         Ok(self.filename.as_str()?.ends_with('/'))
     }
-    
+
     /// Returns whether or not the entry has a data descriptor.
     pub fn data_descriptor(&self) -> bool {
         self.data_descriptor

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,8 @@ pub enum ZipError {
     InvalidExtraFieldHeader(u16, usize),
     #[error("zip64 extended information field was incomplete")]
     Zip64ExtendedFieldIncomplete,
+    #[error("an extra field with id {0:#x} was duplicated in the header")]
+    DuplicateExtraFieldHeader(u16),
 
     #[error("an upstream reader returned an error: {0}")]
     UpstreamReadError(#[from] std::io::Error),

--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -67,7 +67,7 @@ impl ExtraFieldAsBytes for UnknownExtraField {
 impl ExtraFieldAsBytes for Zip64ExtendedInformationExtraField {
     fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
-        let header_id: u16 = self.header_id.into();
+        let header_id: u16 = HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD.into();
         bytes.append(&mut header_id.to_le_bytes().to_vec());
         bytes.append(&mut (self.content_size() as u16).to_le_bytes().to_vec());
         if let Some(uncompressed_size) = &self.uncompressed_size {
@@ -156,7 +156,7 @@ impl ExtraFieldAsBytes for InfoZipUnicodePathExtraField {
 /// Parse a zip64 extra field from bytes.
 /// The content of "data" should exclude the header.
 fn zip64_extended_information_field_from_bytes(
-    header_id: HeaderId,
+    _header_id: HeaderId,
     data: &[u8],
     uncompressed_size: u32,
     compressed_size: u32,
@@ -197,7 +197,6 @@ fn zip64_extended_information_field_from_bytes(
     };
 
     Ok(Zip64ExtendedInformationExtraField {
-        header_id,
         uncompressed_size,
         compressed_size,
         relative_header_offset,
@@ -278,7 +277,6 @@ impl Zip64ExtendedInformationExtraFieldBuilder {
     pub fn new() -> Self {
         Self {
             field: Zip64ExtendedInformationExtraField {
-                header_id: HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
                 uncompressed_size: None,
                 compressed_size: None,
                 relative_header_offset: None,

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -57,12 +57,23 @@ pub enum ExtraField {
     Unknown(UnknownExtraField),
 }
 
+impl ExtraField {
+    /// Returns the [`HeaderId`] of the extra field.
+    pub fn header_id(&self) -> HeaderId {
+        match self {
+            ExtraField::Zip64ExtendedInformation(..) => HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
+            ExtraField::InfoZipUnicodeComment(..) => HeaderId::INFO_ZIP_UNICODE_COMMENT_EXTRA_FIELD,
+            ExtraField::InfoZipUnicodePath(..) => HeaderId::INFO_ZIP_UNICODE_PATH_EXTRA_FIELD,
+            ExtraField::Unknown(field) => field.header_id,
+        }
+    }
+}
+
 /// An extended information header for Zip64.
 /// This field is used both for local file headers and central directory records.
 /// https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#453
 #[derive(Clone, Debug)]
 pub struct Zip64ExtendedInformationExtraField {
-    pub header_id: HeaderId,
     pub uncompressed_size: Option<u64>,
     pub compressed_size: Option<u64>,
     // While not specified in the spec, these two fields are often left out in practice.


### PR DESCRIPTION
## Summary

If a header appears multiple times in the extra field, reject the zip.