### PR TITLE
Remove some differentials with other zip parsers

### DIFF
--- a/src/base/read/counting.rs
+++ b/src/base/read/counting.rs
@@ -1,0 +1,65 @@
+use std::io;
+use std::io::Read;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_lite::io::AsyncBufRead;
+use futures_lite::io::AsyncRead;
+
+/// A wrapper around a reader that counts the number of bytes read.
+pub struct Counting<R> {
+    inner: R,
+    bytes: u64,
+}
+
+impl<R> Counting<R> {
+    /// Creates a new [`Counting`] reader that wraps the provided inner reader.
+    pub fn new(inner: R) -> Self {
+        Self { inner, bytes: 0 }
+    }
+
+    /// Returns the number of bytes read so far.
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes
+    }
+
+    /// Consumes the [`Counting`] reader and returns the inner reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: Read> Read for Counting<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes += n as u64;
+        Ok(n)
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for Counting<R> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+
+        match Pin::new(&mut this.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(n)) => {
+                this.bytes += n as u64;
+                Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
+    }
+}
+
+impl<R: AsyncBufRead + Unpin> AsyncBufRead for Counting<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        this.bytes += amt as u64;
+        Pin::new(&mut this.inner).consume(amt);
+    }
+}

--- a/src/base/read/stream.rs
+++ b/src/base/read/stream.rs
@@ -46,11 +46,7 @@
 //! # }
 //! ```
 
-use std::io;
-use std::io::Read;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
+use crate::base::read::counting::Counting;
 use crate::base::read::io::entry::ZipEntryReader;
 use crate::error::Result;
 use crate::error::ZipError;
@@ -59,71 +55,12 @@ use crate::spec::data_descriptor::DataDescriptor;
 use crate::tokio::read::stream::Ready as TokioReady;
 
 use futures_lite::io::AsyncBufRead;
-use futures_lite::io::AsyncRead;
 use futures_lite::io::AsyncReadExt;
 
 use super::io::entry::WithEntry;
 use super::io::entry::WithoutEntry;
 #[cfg(feature = "tokio")]
 use tokio_util::compat::TokioAsyncReadCompatExt;
-
-/// A wrapper around a reader that counts the number of bytes read.
-pub struct Counting<R> {
-    inner: R,
-    bytes: u64,
-}
-
-impl<R> Counting<R> {
-    /// Creates a new [`Counting`] reader that wraps the provided inner reader.
-    pub fn new(inner: R) -> Self {
-        Self { inner, bytes: 0 }
-    }
-
-    /// Returns the number of bytes read so far.
-    pub fn bytes_read(&self) -> u64 {
-        self.bytes
-    }
-
-    /// Consumes the [`Counting`] reader and returns the inner reader.
-    pub fn into_inner(self) -> R {
-        self.inner
-    }
-}
-
-impl<R: Read> Read for Counting<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.inner.read(buf)?;
-        self.bytes += n as u64;
-        Ok(n)
-    }
-}
-
-impl<R: AsyncRead + Unpin> AsyncRead for Counting<R> {
-    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
-        let this = self.get_mut();
-
-        match Pin::new(&mut this.inner).poll_read(cx, buf) {
-            Poll::Ready(Ok(n)) => {
-                this.bytes += n as u64;
-                Poll::Ready(Ok(n))
-            }
-            other => other,
-        }
-    }
-}
-
-impl<R: AsyncBufRead + Unpin> AsyncBufRead for Counting<R> {
-    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        let this = self.get_mut();
-        Pin::new(&mut this.inner).poll_fill_buf(cx)
-    }
-
-    fn consume(self: Pin<&mut Self>, amt: usize) {
-        let this = self.get_mut();
-        this.bytes += amt as u64;
-        Pin::new(&mut this.inner).consume(amt);
-    }
-}
 
 /// A type which encodes that [`ZipFileReader`] is ready to open a new entry.
 pub struct Ready<R>(R);

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,4 +71,9 @@ pub enum ZipError {
     InfoZipUnicodeCommentFieldIncomplete,
     #[error("Info-ZIP Unicode Path Extra Field was incomplete")]
     InfoZipUnicodePathFieldIncomplete,
+
+    #[error("the zip64 end of central directory locator was not found")]
+    MissingZip64EndOfCentralDirectoryLocator,
+    #[error("the zip64 end of central directory locator offset ({0:#x}) did not match the actual offset ({1:#x})")]
+    InvalidZip64EndOfCentralDirectoryLocatorOffset(u64, u64),
 }

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -320,7 +320,7 @@ pub fn parse_extra_fields(data: Vec<u8>, uncompressed_size: u32, compressed_size
     while cursor + 4 < data.len() {
         let header_id: HeaderId = u16::from_le_bytes(data[cursor..cursor + 2].try_into().unwrap()).into();
         let field_size = u16::from_le_bytes(data[cursor + 2..cursor + 4].try_into().unwrap());
-        if cursor + 4 + field_size as usize > data.len() {
+        if cursor + 8 + field_size as usize > data.len() {
             return Err(ZipError::InvalidExtraFieldHeader(field_size, data.len() - cursor - 8 - field_size as usize));
         }
 


### PR DESCRIPTION
## Summary

Make sure we respect the ZIP64 extra fields in the central directory record; prefer the extra field name over the Unicode name.