### PR TITLE
Use stricter enforcement for ZIP64 extra field

### DIFF
--- a/src/base/read/cd.rs
+++ b/src/base/read/cd.rs
@@ -172,7 +172,13 @@ where
         // next record.
         let filename_basic = io::read_bytes(&mut self.reader, header.file_name_length.into()).await?;
         let extra_field = io::read_bytes(&mut self.reader, header.extra_field_length.into()).await?;
-        let extra_fields = parse_extra_fields(extra_field, header.uncompressed_size, header.compressed_size)?;
+        let extra_fields = parse_extra_fields(
+            extra_field,
+            header.uncompressed_size,
+            header.compressed_size,
+            Some(header.lh_offset),
+            Some(header.disk_start),
+        )?;
         let zip64_extra_field = get_zip64_extra_field(&extra_fields);
 
         // Reconcile the compressed size, uncompressed size, and file offset, using ZIP64 if necessary.

--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -151,7 +151,13 @@ where
     let filename_basic = io::read_bytes(&mut reader, header.file_name_length.into()).await?;
     let compression = Compression::try_from(header.compression)?;
     let extra_field = io::read_bytes(&mut reader, header.extra_field_length.into()).await?;
-    let extra_fields = parse_extra_fields(extra_field, header.uncompressed_size, header.compressed_size)?;
+    let extra_fields = parse_extra_fields(
+        extra_field,
+        header.uncompressed_size,
+        header.compressed_size,
+        Some(header.lh_offset),
+        Some(header.disk_start),
+    )?;
     let comment_basic = io::read_bytes(reader, header.file_comment_length.into()).await?;
 
     let zip64_extra_field = get_zip64_extra_field(&extra_fields);
@@ -218,7 +224,7 @@ where
     let filename_basic = io::read_bytes(&mut reader, header.file_name_length.into()).await?;
     let compression = Compression::try_from(header.compression)?;
     let extra_field = io::read_bytes(&mut reader, header.extra_field_length.into()).await?;
-    let extra_fields = parse_extra_fields(extra_field, header.uncompressed_size, header.compressed_size)?;
+    let extra_fields = parse_extra_fields(extra_field, header.uncompressed_size, header.compressed_size, None, None)?;
 
     let zip64_extra_field = get_zip64_extra_field(&extra_fields);
     let (uncompressed_size, compressed_size) =

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,4 +76,10 @@ pub enum ZipError {
     MissingZip64EndOfCentralDirectoryLocator,
     #[error("the zip64 end of central directory locator offset ({0:#x}) did not match the actual offset ({1:#x})")]
     InvalidZip64EndOfCentralDirectoryLocatorOffset(u64, u64),
+    #[error("zip64 extended information field was too short: expected {expected} bytes, but only {actual} bytes were provided")]
+    Zip64ExtendedInformationFieldTooShort { expected: usize, actual: usize },
+    #[error(
+        "zip64 extended information field was too long: expected {expected} bytes, but {actual} bytes were provided"
+    )]
+    Zip64ExtendedInformationFieldTooLong { expected: usize, actual: usize },
 }

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -220,7 +220,13 @@ impl Zip64EndOfCentralDirectoryLocator {
 }
 
 /// Parse the extra fields.
-pub fn parse_extra_fields(data: Vec<u8>, uncompressed_size: u32, compressed_size: u32) -> Result<Vec<ExtraField>> {
+pub fn parse_extra_fields(
+    data: Vec<u8>,
+    uncompressed_size: u32,
+    compressed_size: u32,
+    relative_header_offset: Option<u32>,
+    disk_start_number: Option<u16>,
+) -> Result<Vec<ExtraField>> {
     let mut cursor = 0;
     let mut extra_fields = Vec::<ExtraField>::new();
 
@@ -233,7 +239,15 @@ pub fn parse_extra_fields(data: Vec<u8>, uncompressed_size: u32, compressed_size
 
         // Decode the extra field data.
         let data = &data[cursor + 4..cursor + 4 + field_size as usize];
-        let extra_field = extra_field_from_bytes(header_id, field_size, data, uncompressed_size, compressed_size)?;
+        let extra_field = extra_field_from_bytes(
+            header_id,
+            field_size,
+            data,
+            uncompressed_size,
+            compressed_size,
+            relative_header_offset,
+            disk_start_number,
+        )?;
 
         // Verify that the extra field doesn't contain duplicates.
         for seen in &extra_fields {


### PR DESCRIPTION
## Summary

Only read the relative offset and disk start fields if they're at maximum values, and verify that the extra as a whole has the correct length.