### PR TITLE
Validate EOCDR offset within the reader

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,8 @@ pub enum ZipError {
     #[error("Info-ZIP Unicode Path Extra Field was incomplete")]
     InfoZipUnicodePathFieldIncomplete,
 
+    #[error("the end of central directory offset ({0:#x}) did not match the actual offset ({1:#x})")]
+    InvalidEndOfCentralDirectoryOffset(u64, u64),
     #[error("the zip64 end of central directory locator was not found")]
     MissingZip64EndOfCentralDirectoryLocator,
     #[error("the zip64 end of central directory locator offset ({0:#x}) did not match the actual offset ({1:#x})")]


### PR DESCRIPTION
## Summary

We validate the ZIP64 EOCDR here, so it makes sense to do the EOCDR itself too.