### PR TITLE
Bump thiserror dependency to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 crc32fast = "1"
 futures-lite = { version = "2.1.0", default-features = false, features = ["std"] }
 pin-project = "1"
-thiserror = "1"
+thiserror = "2.0.18"
 
 async-compression = { version = "0.4.2", default-features = false, features = ["futures-io"], optional = true }
 tokio = { version = "1", default-features = false, optional = true }


### PR DESCRIPTION
To get rid of the duplicate version of `thiserror` in our dependency tree.

```console
❯ cargo tree -i thiserror@1.0.69
thiserror v1.0.69
└── astral_async_zip v0.0.17
    └── prek v0.3.1 (/Users/Jo/code/rust/prek/crates/prek)
```
