### PR TITLE
Fix zip64 extended information field parsing for central directory entries

### DIFF
--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -59,12 +59,9 @@ fn zip64_extended_information_field_from_bytes(
         // uncompressed and compressed sizes equal to the local header sizes. We accept these, even
         // though they are not strictly compliant with the spec.
         if current_idx == 0 && data.len() == 16 {
-            let uncompressed_size = u64::from_le_bytes(data[current_idx..current_idx + 8].try_into().unwrap());
-            let compressed_size = u64::from_le_bytes(data[current_idx + 8..current_idx + 16].try_into().unwrap());
-            if uncompressed_size == header_uncompressed_size as u64
-                && compressed_size == header_compressed_size as u64
-                && header_relative_header_offset.is_none()
-                && header_disk_start_number.is_none()
+            let uncompressed_size = u64::from_le_bytes(data[0..8].try_into().unwrap());
+            let compressed_size = u64::from_le_bytes(data[8..16].try_into().unwrap());
+            if uncompressed_size == header_uncompressed_size as u64 && compressed_size == header_compressed_size as u64
             {
                 return Ok(Zip64ExtendedInformationExtraField {
                     uncompressed_size: Some(uncompressed_size),
@@ -157,5 +154,57 @@ pub(crate) fn extra_field_from_bytes(
             info_zip_unicode_path_extra_field_from_bytes(header_id, data_size, data)?,
         )),
         _ => Ok(ExtraField::Unknown(UnknownExtraField { header_id, data_size, content: data.to_vec() })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zip64_extra_field_cd_with_redundant_sizes_accepted() {
+        // Simulate a central directory entry produced by conda-build / Python's zipfile module:
+        // a zip64 extra field is present even though the sizes fit in 32 bits (no sentinel).
+        // For central directory entries, header_relative_header_offset and
+        // header_disk_start_number are always Some(_), not None.
+        let data: [u8; 16] = [
+            30, 0, 0, 0, 0, 0, 0, 0, // uncompressed_size = 30u64 LE
+            30, 0, 0, 0, 0, 0, 0, 0, // compressed_size   = 30u64 LE
+        ];
+        let result = zip64_extended_information_field_from_bytes(
+            HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
+            &data,
+            30,      // header_uncompressed_size (not sentinel 0xFFFFFFFF)
+            30,      // header_compressed_size   (not sentinel 0xFFFFFFFF)
+            Some(0), // header_relative_header_offset (central directory always provides this)
+            Some(0), // header_disk_start_number      (central directory always provides this)
+        );
+        assert!(result.is_ok(), "expected Ok but got: {:?}", result.err());
+        let field = result.unwrap();
+        assert_eq!(field.uncompressed_size, Some(30));
+        assert_eq!(field.compressed_size, Some(30));
+        assert_eq!(field.relative_header_offset, None);
+        assert_eq!(field.disk_start_number, None);
+    }
+
+    #[test]
+    fn zip64_extra_field_local_header_with_redundant_sizes_still_accepted() {
+        // Existing behaviour for local file headers (both Option params are None) must be preserved.
+        let data: [u8; 16] = [
+            5, 0, 0, 0, 0, 0, 0, 0, // uncompressed = 5
+            5, 0, 0, 0, 0, 0, 0, 0, // compressed   = 5
+        ];
+        let result = zip64_extended_information_field_from_bytes(
+            HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD,
+            &data,
+            5,
+            5,
+            None,
+            None,
+        );
+        assert!(result.is_ok(), "expected Ok but got: {:?}", result.err());
+        let field = result.unwrap();
+        assert_eq!(field.uncompressed_size, Some(5));
+        assert_eq!(field.compressed_size, Some(5));
     }
 }

--- a/tests/decompress_test.rs
+++ b/tests/decompress_test.rs
@@ -81,3 +81,116 @@ async fn decompress_zip_with_utf8_extra() {
     assert_eq!(zip_entries[0].filename().as_str().unwrap(), "\u{4E2D}\u{6587}.txt");
     assert_eq!(zip_entries[0].filename().alternative(), Some(b"\xD6\xD0\xCe\xC4.txt".as_ref()));
 }
+
+/// Build a minimal in-memory ZIP whose central directory entries include a zip64 extended
+/// information extra field even though all sizes fit in 32 bits (no sentinel values).
+///
+/// This is exactly what Python's `zipfile` module (and conda-build) produces. Before the fix,
+/// parsing such a ZIP with the seek-based or mem-based reader would fail with
+/// `Zip64ExtendedInformationFieldTooLong`.
+fn build_zip_with_cd_redundant_zip64_extra() -> Vec<u8> {
+    let entries: &[(&str, &[u8])] = &[("a.txt", b"aaaaa"), ("b.txt", b"bbbbb"), ("c.txt", b"ccccc")];
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut lh_offsets: Vec<u32> = Vec::new();
+
+    // ---- Local file headers + file data ----
+    for (name, data) in entries {
+        lh_offsets.push(buf.len() as u32);
+        let crc = crc32fast::hash(data);
+        let size32 = data.len() as u32;
+        let size64 = data.len() as u64;
+
+        buf.extend_from_slice(&0x04034b50_u32.to_le_bytes()); // LFH signature
+        buf.extend_from_slice(&45_u16.to_le_bytes()); // version needed (zip64)
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // flags
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // compression (stored)
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // mod time
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // mod date
+        buf.extend_from_slice(&crc.to_le_bytes()); // crc32
+        buf.extend_from_slice(&size32.to_le_bytes()); // compressed size (actual, not sentinel)
+        buf.extend_from_slice(&size32.to_le_bytes()); // uncompressed size (actual, not sentinel)
+        buf.extend_from_slice(&(name.len() as u16).to_le_bytes()); // filename length
+        buf.extend_from_slice(&20_u16.to_le_bytes()); // extra field length (4 hdr + 16 data)
+        buf.extend_from_slice(name.as_bytes()); // filename
+                                                // zip64 extra field
+        buf.extend_from_slice(&0x0001_u16.to_le_bytes()); // header id
+        buf.extend_from_slice(&16_u16.to_le_bytes()); // data size
+        buf.extend_from_slice(&size64.to_le_bytes()); // uncompressed size as u64
+        buf.extend_from_slice(&size64.to_le_bytes()); // compressed size as u64
+        buf.extend_from_slice(data); // file data
+    }
+
+    let cd_offset = buf.len() as u32;
+
+    // ---- Central directory ----
+    for (i, (name, data)) in entries.iter().enumerate() {
+        let crc = crc32fast::hash(data);
+        let size32 = data.len() as u32;
+        let size64 = data.len() as u64;
+
+        buf.extend_from_slice(&0x02014b50_u32.to_le_bytes()); // CDH signature
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // version made by
+        buf.extend_from_slice(&45_u16.to_le_bytes()); // version needed
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // flags
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // compression
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // mod time
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // mod date
+        buf.extend_from_slice(&crc.to_le_bytes()); // crc32
+        buf.extend_from_slice(&size32.to_le_bytes()); // compressed size (actual, not sentinel)
+        buf.extend_from_slice(&size32.to_le_bytes()); // uncompressed size (actual, not sentinel)
+        buf.extend_from_slice(&(name.len() as u16).to_le_bytes()); // filename length
+        buf.extend_from_slice(&20_u16.to_le_bytes()); // extra field length
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // comment length
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // disk start (Some(0) in parse)
+        buf.extend_from_slice(&0_u16.to_le_bytes()); // internal attributes
+        buf.extend_from_slice(&0_u32.to_le_bytes()); // external attributes
+        buf.extend_from_slice(&lh_offsets[i].to_le_bytes()); // LFH offset (Some(x) in parse)
+        buf.extend_from_slice(name.as_bytes()); // filename
+                                                // zip64 extra field — same redundant format as in the LFH
+        buf.extend_from_slice(&0x0001_u16.to_le_bytes()); // header id
+        buf.extend_from_slice(&16_u16.to_le_bytes()); // data size
+        buf.extend_from_slice(&size64.to_le_bytes()); // uncompressed size as u64
+        buf.extend_from_slice(&size64.to_le_bytes()); // compressed size as u64
+    }
+
+    let cd_size = buf.len() as u32 - cd_offset;
+
+    // ---- End of central directory record ----
+    buf.extend_from_slice(&0x06054b50_u32.to_le_bytes()); // EOCDR signature
+    buf.extend_from_slice(&0_u16.to_le_bytes()); // disk number
+    buf.extend_from_slice(&0_u16.to_le_bytes()); // start disk
+    buf.extend_from_slice(&(entries.len() as u16).to_le_bytes()); // entries on this disk
+    buf.extend_from_slice(&(entries.len() as u16).to_le_bytes()); // total entries
+    buf.extend_from_slice(&cd_size.to_le_bytes()); // CD size
+    buf.extend_from_slice(&cd_offset.to_le_bytes()); // CD offset
+    buf.extend_from_slice(&0_u16.to_le_bytes()); // comment length
+
+    buf
+}
+
+/// Regression test for conda-build / Python zipfile-style archives: central directory entries
+/// carry a zip64 extra field with redundant (non-sentinel) sizes. Before the fix this returned
+/// `Zip64ExtendedInformationFieldTooLong`.
+#[tokio::test]
+async fn cd_zip64_extra_with_non_sentinel_sizes_is_readable() {
+    let zip_data = build_zip_with_cd_redundant_zip64_extra();
+    let zip = async_zip::base::read::mem::ZipFileReader::new(zip_data)
+        .await
+        .expect("reading a ZIP with redundant zip64 extra fields in the central directory should succeed");
+
+    let expected: &[(&str, &[u8])] = &[("a.txt", b"aaaaa"), ("b.txt", b"bbbbb"), ("c.txt", b"ccccc")];
+    assert_eq!(zip.file().entries().len(), expected.len());
+
+    for (idx, (name, content)) in expected.iter().enumerate() {
+        let entry = &zip.file().entries()[idx];
+        assert_eq!(entry.filename().as_str().unwrap(), *name);
+        assert_eq!(entry.uncompressed_size(), 5);
+        assert_eq!(entry.compressed_size(), 5);
+
+        let mut buf = Vec::new();
+        let mut reader = zip.reader_with_entry(idx).await.unwrap();
+        reader.read_to_end_checked(&mut buf).await.expect("CRC check should pass");
+        assert_eq!(buf.as_slice(), *content);
+    }
+}


### PR DESCRIPTION
`zip64_extended_information_field_from_bytes` rejected valid ZIP archives where central directory entries include a zip64 extra field with sizes that fit in 32 bits (no sentinel 0xFFFFFFFF values). This pattern is non-standard but extremely common — Python's zipfile module (and conda-build) always emits it.

The function already had a workaround for this case, but it was gated on `header_relative_header_offset.is_none() && header_disk_start_number.is_none()`. Those parameters are always None for local file headers but always Some(_) for central directory entries, so the workaround never fired for the CD path. The result was:

`Zip64ExtendedInformationFieldTooLong { expected: 16, actual: 0 }`

Fix: remove the two `is_none()` guards so the workaround applies to both local file headers and central directory entries.

Fixes parsing of .conda packages from conda-forge (e.g. as reported in conda/rattler#2305).

Note: code written entirely by Claude Code.

