### PR TITLE
Restore asynchronous ZIP writing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ categories = ["asynchronous", "compression"]
 name = "async_zip"
 
 [features]
-full = ["tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
+full = ["chrono", "tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
 
 # All features that are compatible with WASM
-full-wasm = ["deflate", "zstd"]
+full-wasm = ["chrono", "deflate", "zstd"]
 
 tokio = ["dep:tokio", "tokio-util", "tokio/io-util"]
 tokio-fs = ["tokio/fs"]
@@ -47,6 +47,7 @@ thiserror = "2.0.18"
 async-compression = { version = "0.4.2", default-features = false, features = [
     "futures-io",
 ], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 tokio = { version = "1", default-features = false, optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 
@@ -56,3 +57,14 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 env_logger = "0.11.2"
 zip = "2.1.5"
+
+# shared across multiple examples
+anyhow = "1"
+sanitize-filename = "0.5"
+
+# actix_multipart
+actix-web = "4"
+actix-multipart = "0.7"
+futures = "0.3"
+derive_more = { version = "1.0", features = ["display", "error"] }
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/examples/actix_multipart.rs
+++ b/examples/actix_multipart.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 FL33TW00D (https://github.com/FL33TW00D)
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE
+
+#[cfg(features = "deflate")]
+mod inner {
+    use async_zip::write::ZipFileWriter;
+    use async_zip::{Compression, ZipEntryBuilder};
+
+    use std::path::Path;
+
+    use actix_multipart::Multipart;
+    use actix_web::{web, App, HttpServer, Responder, ResponseError, Result};
+    use derive_more::{Display, Error};
+    use futures::StreamExt;
+    use futures_lite::io::AsyncWriteExt;
+    use tokio::fs::File;
+    use uuid::Uuid;
+
+    const TMP_DIR: &str = "./tmp/";
+
+    #[derive(Debug, Display, Error)]
+    #[display("An error occurred during ZIP creation which was logged to stderr.")]
+    struct CreationError;
+
+    impl ResponseError for CreationError {}
+
+    async fn do_main() -> std::io::Result<()> {
+        let tmp_path = Path::new(TMP_DIR);
+
+        if !tmp_path.exists() {
+            tokio::fs::create_dir(tmp_path).await?;
+        }
+
+        let factory = || App::new().route("/", web::post().to(handler));
+        HttpServer::new(factory).bind(("127.0.0.1", 8080))?.run().await
+    }
+
+    async fn handler(multipart: Multipart) -> Result<impl Responder, CreationError> {
+        match create_archive(multipart).await {
+            Ok(name) => Ok(format!("Successfully created archive: {}", name)),
+            Err(err) => {
+                eprintln!("[ERROR] {:?}", err);
+                Err(CreationError)
+            }
+        }
+    }
+
+    async fn create_archive(mut body: Multipart) -> Result<String, anyhow::Error> {
+        let archive_name = format!("tmp/{}", Uuid::new_v4());
+        let mut archive = File::create(archive_name.clone()).await?;
+        let mut writer = ZipFileWriter::new(&mut archive);
+
+        while let Some(item) = body.next().await {
+            let mut field = item?;
+
+            let filename = match field.content_disposition().get_filename() {
+                Some(filename) => sanitize_filename::sanitize(filename),
+                None => Uuid::new_v4().to_string(),
+            };
+
+            let builder = ZipEntryBuilder::new(filename, Compression::Deflate);
+            let mut entry_writer = writer.write_entry_stream(builder).await.unwrap();
+
+            while let Some(chunk) = field.next().await {
+                entry_writer.write_all_buf(&mut chunk?).await?;
+            }
+
+            entry_writer.close().await.unwrap();
+        }
+
+        writer.close().await.unwrap();
+        archive.shutdown().await.unwrap();
+
+        Ok(archive_name)
+    }
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    #[cfg(features = "deflate")]
+    {
+        inner::do_main().await?;
+    }
+
+    Ok(())
+}

--- a/examples/cli_compress.rs
+++ b/examples/cli_compress.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+#[tokio::main]
+async fn main() {
+    #[cfg(features = "deflate")]
+    if let Err(err) = inner::run().await {
+        eprintln!("Error: {}", err);
+        eprintln!("Usage: cli_compress <input file or directory> <output ZIP file name>");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(features = "deflate")]
+mod inner {
+
+    use async_zip::base::write::ZipFileWriter;
+    use async_zip::{Compression, ZipEntryBuilder};
+
+    use std::path::{Path, PathBuf};
+
+    use anyhow::{anyhow, bail, Result};
+    use futures_lite::io::AsyncReadExt;
+    use tokio::fs::File;
+
+    async fn run() -> Result<()> {
+        let mut args = std::env::args().skip(1);
+
+        let input_str = args.next().ok_or(anyhow!("No input file or directory specified."))?;
+        let input_path = Path::new(&input_str);
+
+        let output_str = args.next().ok_or(anyhow!("No output file specified."))?;
+        let output_path = Path::new(&output_str);
+
+        let input_pathbuf = input_path.canonicalize().map_err(|_| anyhow!("Unable to canonicalise input path."))?;
+        let input_path = input_pathbuf.as_path();
+
+        if output_path.exists() {
+            bail!("The output file specified already exists.");
+        }
+        if !input_path.exists() {
+            bail!("The input file or directory specified doesn't exist.");
+        }
+
+        let mut output_writer = ZipFileWriter::new(File::create(output_path).await?);
+
+        if input_path.is_dir() {
+            handle_directory(input_path, &mut output_writer).await?;
+        } else {
+            handle_singular(input_path, &mut output_writer).await?;
+        }
+
+        output_writer.close().await?;
+        println!("Successfully written ZIP file '{}'.", output_path.display());
+
+        Ok(())
+    }
+
+    async fn handle_singular(input_path: &Path, writer: &mut ZipFileWriter<File>) -> Result<()> {
+        let filename = input_path.file_name().ok_or(anyhow!("Input path terminates in '...'."))?;
+        let filename = filename.to_str().ok_or(anyhow!("Input path not valid UTF-8."))?;
+
+        write_entry(filename, input_path, writer).await
+    }
+
+    async fn handle_directory(input_path: &Path, writer: &mut ZipFileWriter<File>) -> Result<()> {
+        let entries = walk_dir(input_path.into()).await?;
+        let input_dir_str = input_path.as_os_str().to_str().ok_or(anyhow!("Input path not valid UTF-8."))?;
+
+        for entry_path_buf in entries {
+            let entry_path = entry_path_buf.as_path();
+            let entry_str = entry_path.as_os_str().to_str().ok_or(anyhow!("Directory file path not valid UTF-8."))?;
+
+            if !entry_str.starts_with(input_dir_str) {
+                bail!("Directory file path does not start with base input directory path.");
+            }
+
+            let entry_str = &entry_str[input_dir_str.len() + 1..];
+            write_entry(entry_str, entry_path, writer).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn write_entry(filename: &str, input_path: &Path, writer: &mut ZipFileWriter<File>) -> Result<()> {
+        let mut input_file = File::open(input_path).await?;
+        let input_file_size = input_file.metadata().await?.len() as usize;
+
+        let mut buffer = Vec::with_capacity(input_file_size);
+        input_file.read_to_end(&mut buffer).await?;
+
+        let builder = ZipEntryBuilder::new(filename.into(), Compression::Deflate);
+        writer.write_entry_whole(builder, &buffer).await?;
+
+        Ok(())
+    }
+
+    async fn walk_dir(dir: PathBuf) -> Result<Vec<PathBuf>> {
+        let mut dirs = vec![dir];
+        let mut files = vec![];
+
+        while !dirs.is_empty() {
+            let mut dir_iter = tokio::fs::read_dir(dirs.remove(0)).await?;
+
+            while let Some(entry) = dir_iter.next_entry().await? {
+                let entry_path_buf = entry.path();
+
+                if entry_path_buf.is_dir() {
+                    dirs.push(entry_path_buf);
+                } else {
+                    files.push(entry_path_buf);
+                }
+            }
+        }
+
+        Ok(files)
+    }
+}

--- a/examples/file_extraction.rs
+++ b/examples/file_extraction.rs
@@ -1,0 +1,82 @@
+//! Demonstrates how to safely extract everything from a ZIP file.
+//!
+//! Extracting zip files from untrusted sources without proper sanitization
+//! could be exploited by directory traversal attacks.
+//! <https://en.wikipedia.org/wiki/Directory_traversal_attack#Archives>
+//!
+//! This example tries to minimize that risk by following the implementation from
+//! Python's Standard Library.
+//! <https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extract>
+//! <https://github.com/python/cpython/blob/ac0a19b62ae137c2c9f53fbba8ba3f769acf34dc/Lib/zipfile.py#L1662>
+//!
+
+use std::{
+    env::current_dir,
+    path::{Path, PathBuf},
+};
+
+use async_zip::base::read::seek::ZipFileReader;
+use tokio::{
+    fs::{create_dir_all, File, OpenOptions},
+    io::BufReader,
+};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+#[tokio::main]
+async fn main() {
+    let archive = File::open("example.zip").await.expect("Failed to open zip file");
+    let out_dir = current_dir().expect("Failed to get current working directory");
+    unzip_file(archive, &out_dir).await;
+}
+
+/// Returns a relative path without reserved names, redundant separators, ".", or "..".
+fn sanitize_file_path(path: &str) -> PathBuf {
+    // Replaces backwards slashes
+    path.replace('\\', "/")
+        // Sanitizes each component
+        .split('/')
+        .map(sanitize_filename::sanitize)
+        .collect()
+}
+
+/// Extracts everything from the ZIP archive to the output directory
+async fn unzip_file(archive: File, out_dir: &Path) {
+    let archive = BufReader::new(archive).compat();
+    let mut reader = ZipFileReader::new(archive).await.expect("Failed to read zip file");
+    for index in 0..reader.file().entries().len() {
+        let entry = reader.file().entries().get(index).unwrap();
+        let path = out_dir.join(sanitize_file_path(entry.filename().as_str().unwrap()));
+        // If the filename of the entry ends with '/', it is treated as a directory.
+        // This is implemented by previous versions of this crate and the Python Standard Library.
+        // https://docs.rs/async_zip/0.0.8/src/async_zip/read/mod.rs.html#63-65
+        // https://github.com/python/cpython/blob/820ef62833bd2d84a141adedd9a05998595d6b6d/Lib/zipfile.py#L528
+        let entry_is_dir = entry.dir().unwrap();
+
+        let mut entry_reader = reader.reader_without_entry(index).await.expect("Failed to read ZipEntry");
+
+        if entry_is_dir {
+            // The directory may have been created if iteration is out of order.
+            if !path.exists() {
+                create_dir_all(&path).await.expect("Failed to create extracted directory");
+            }
+        } else {
+            // Creates parent directories. They may not exist if iteration is out of order
+            // or the archive does not contain directory entries.
+            let parent = path.parent().expect("A file entry should have parent directories");
+            if !parent.is_dir() {
+                create_dir_all(parent).await.expect("Failed to create parent directories");
+            }
+            let writer = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .await
+                .expect("Failed to create extracted file");
+            futures_lite::io::copy(&mut entry_reader, &mut writer.compat_write())
+                .await
+                .expect("Failed to copy to extracted file");
+
+            // Closes the file and manipulates its metadata here if you wish to preserve its metadata from the archive.
+        }
+    }
+}

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -4,3 +4,4 @@
 //! A base runtime-agnostic implementation using `futures`'s IO types.
 
 pub mod read;
+pub mod write;

--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -147,6 +147,17 @@ pub(crate) fn get_zip64_extra_field(extra_fields: &[ExtraField]) -> Option<&Zip6
     None
 }
 
+pub(crate) fn get_zip64_extra_field_mut(
+    extra_fields: &mut [ExtraField],
+) -> Option<&mut Zip64ExtendedInformationExtraField> {
+    for field in extra_fields {
+        if let ExtraField::Zip64ExtendedInformation(zip64field) = field {
+            return Some(zip64field);
+        }
+    }
+    None
+}
+
 fn get_combined_sizes(
     uncompressed_size: u32,
     compressed_size: u32,
@@ -335,7 +346,7 @@ fn detect_comment(basic: Vec<u8>, basic_is_utf8: bool, extra_fields: &[ExtraFiel
 fn detect_filename(basic: Vec<u8>, basic_is_utf8: bool, extra_fields: &[ExtraField]) -> ZipString {
     let unicode_extra = extra_fields.iter().find_map(|field| match field {
         ExtraField::InfoZipUnicodePath(InfoZipUnicodePathExtraField::V1 { crc32, unicode }) => {
-            if !unicode.is_empty() && *crc32 == crc32fast::hash(&basic) {
+            if unicode.len() > 0 && *crc32 == crc32fast::hash(&basic) {
                 Some(std::string::String::from_utf8(unicode.clone()))
             } else {
                 None

--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -346,7 +346,7 @@ fn detect_comment(basic: Vec<u8>, basic_is_utf8: bool, extra_fields: &[ExtraFiel
 fn detect_filename(basic: Vec<u8>, basic_is_utf8: bool, extra_fields: &[ExtraField]) -> ZipString {
     let unicode_extra = extra_fields.iter().find_map(|field| match field {
         ExtraField::InfoZipUnicodePath(InfoZipUnicodePathExtraField::V1 { crc32, unicode }) => {
-            if unicode.len() > 0 && *crc32 == crc32fast::hash(&basic) {
+            if !unicode.is_empty() && *crc32 == crc32fast::hash(&basic) {
                 Some(std::string::String::from_utf8(unicode.clone()))
             } else {
                 None

--- a/src/base/write/compressed_writer.rs
+++ b/src/base/write/compressed_writer.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::base::write::io::offset::AsyncOffsetWriter;
+use crate::spec::Compression;
+
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+use async_compression::futures::write;
+use futures_lite::io::AsyncWrite;
+
+pub enum CompressedAsyncWriter<'b, W: AsyncWrite + Unpin> {
+    Stored(ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>),
+    #[cfg(feature = "deflate")]
+    Deflate(write::DeflateEncoder<ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>>),
+    #[cfg(feature = "bzip2")]
+    Bz(write::BzEncoder<ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>>),
+    #[cfg(feature = "lzma")]
+    Lzma(write::LzmaEncoder<ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>>),
+    #[cfg(feature = "zstd")]
+    Zstd(write::ZstdEncoder<ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>>),
+    #[cfg(feature = "xz")]
+    Xz(write::XzEncoder<ShutdownIgnoredWriter<&'b mut AsyncOffsetWriter<W>>>),
+}
+
+impl<'b, W: AsyncWrite + Unpin> CompressedAsyncWriter<'b, W> {
+    pub fn from_raw(writer: &'b mut AsyncOffsetWriter<W>, compression: Compression) -> Self {
+        match compression {
+            Compression::Stored => CompressedAsyncWriter::Stored(ShutdownIgnoredWriter(writer)),
+            #[cfg(feature = "deflate")]
+            Compression::Deflate => {
+                CompressedAsyncWriter::Deflate(write::DeflateEncoder::new(ShutdownIgnoredWriter(writer)))
+            }
+            #[cfg(feature = "deflate64")]
+            Compression::Deflate64 => panic!("writing deflate64 is not supported"),
+            #[cfg(feature = "bzip2")]
+            Compression::Bz => CompressedAsyncWriter::Bz(write::BzEncoder::new(ShutdownIgnoredWriter(writer))),
+            #[cfg(feature = "lzma")]
+            Compression::Lzma => CompressedAsyncWriter::Lzma(write::LzmaEncoder::new(ShutdownIgnoredWriter(writer))),
+            #[cfg(feature = "zstd")]
+            Compression::Zstd => CompressedAsyncWriter::Zstd(write::ZstdEncoder::new(ShutdownIgnoredWriter(writer))),
+            #[cfg(feature = "xz")]
+            Compression::Xz => CompressedAsyncWriter::Xz(write::XzEncoder::new(ShutdownIgnoredWriter(writer))),
+        }
+    }
+
+    pub fn into_inner(self) -> &'b mut AsyncOffsetWriter<W> {
+        match self {
+            CompressedAsyncWriter::Stored(inner) => inner.into_inner(),
+            #[cfg(feature = "deflate")]
+            CompressedAsyncWriter::Deflate(inner) => inner.into_inner().into_inner(),
+            #[cfg(feature = "bzip2")]
+            CompressedAsyncWriter::Bz(inner) => inner.into_inner().into_inner(),
+            #[cfg(feature = "lzma")]
+            CompressedAsyncWriter::Lzma(inner) => inner.into_inner().into_inner(),
+            #[cfg(feature = "zstd")]
+            CompressedAsyncWriter::Zstd(inner) => inner.into_inner().into_inner(),
+            #[cfg(feature = "xz")]
+            CompressedAsyncWriter::Xz(inner) => inner.into_inner().into_inner(),
+        }
+    }
+}
+
+impl<'b, W: AsyncWrite + Unpin> AsyncWrite for CompressedAsyncWriter<'b, W> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        match *self {
+            CompressedAsyncWriter::Stored(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+            #[cfg(feature = "deflate")]
+            CompressedAsyncWriter::Deflate(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+            #[cfg(feature = "bzip2")]
+            CompressedAsyncWriter::Bz(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+            #[cfg(feature = "lzma")]
+            CompressedAsyncWriter::Lzma(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+            #[cfg(feature = "zstd")]
+            CompressedAsyncWriter::Zstd(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+            #[cfg(feature = "xz")]
+            CompressedAsyncWriter::Xz(ref mut inner) => Pin::new(inner).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        match *self {
+            CompressedAsyncWriter::Stored(ref mut inner) => Pin::new(inner).poll_flush(cx),
+            #[cfg(feature = "deflate")]
+            CompressedAsyncWriter::Deflate(ref mut inner) => Pin::new(inner).poll_flush(cx),
+            #[cfg(feature = "bzip2")]
+            CompressedAsyncWriter::Bz(ref mut inner) => Pin::new(inner).poll_flush(cx),
+            #[cfg(feature = "lzma")]
+            CompressedAsyncWriter::Lzma(ref mut inner) => Pin::new(inner).poll_flush(cx),
+            #[cfg(feature = "zstd")]
+            CompressedAsyncWriter::Zstd(ref mut inner) => Pin::new(inner).poll_flush(cx),
+            #[cfg(feature = "xz")]
+            CompressedAsyncWriter::Xz(ref mut inner) => Pin::new(inner).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        match *self {
+            CompressedAsyncWriter::Stored(ref mut inner) => Pin::new(inner).poll_close(cx),
+            #[cfg(feature = "deflate")]
+            CompressedAsyncWriter::Deflate(ref mut inner) => Pin::new(inner).poll_close(cx),
+            #[cfg(feature = "bzip2")]
+            CompressedAsyncWriter::Bz(ref mut inner) => Pin::new(inner).poll_close(cx),
+            #[cfg(feature = "lzma")]
+            CompressedAsyncWriter::Lzma(ref mut inner) => Pin::new(inner).poll_close(cx),
+            #[cfg(feature = "zstd")]
+            CompressedAsyncWriter::Zstd(ref mut inner) => Pin::new(inner).poll_close(cx),
+            #[cfg(feature = "xz")]
+            CompressedAsyncWriter::Xz(ref mut inner) => Pin::new(inner).poll_close(cx),
+        }
+    }
+}
+
+pub struct ShutdownIgnoredWriter<W: AsyncWrite + Unpin>(W);
+
+impl<W: AsyncWrite + Unpin> ShutdownIgnoredWriter<W> {
+    pub fn into_inner(self) -> W {
+        self.0
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for ShutdownIgnoredWriter<W> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/base/write/compressed_writer.rs
+++ b/src/base/write/compressed_writer.rs
@@ -2,6 +2,9 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use crate::base::write::io::offset::AsyncOffsetWriter;
+use crate::error::Result;
+#[cfg(feature = "deflate64")]
+use crate::error::ZipError;
 use crate::spec::Compression;
 
 use std::io::Error;
@@ -27,15 +30,15 @@ pub enum CompressedAsyncWriter<'b, W: AsyncWrite + Unpin> {
 }
 
 impl<'b, W: AsyncWrite + Unpin> CompressedAsyncWriter<'b, W> {
-    pub fn from_raw(writer: &'b mut AsyncOffsetWriter<W>, compression: Compression) -> Self {
-        match compression {
+    pub fn from_raw(writer: &'b mut AsyncOffsetWriter<W>, compression: Compression) -> Result<Self> {
+        Ok(match compression {
             Compression::Stored => CompressedAsyncWriter::Stored(ShutdownIgnoredWriter(writer)),
             #[cfg(feature = "deflate")]
             Compression::Deflate => {
                 CompressedAsyncWriter::Deflate(write::DeflateEncoder::new(ShutdownIgnoredWriter(writer)))
             }
             #[cfg(feature = "deflate64")]
-            Compression::Deflate64 => panic!("writing deflate64 is not supported"),
+            Compression::Deflate64 => return Err(ZipError::FeatureNotSupported("Deflate64 writing")),
             #[cfg(feature = "bzip2")]
             Compression::Bz => CompressedAsyncWriter::Bz(write::BzEncoder::new(ShutdownIgnoredWriter(writer))),
             #[cfg(feature = "lzma")]
@@ -44,7 +47,7 @@ impl<'b, W: AsyncWrite + Unpin> CompressedAsyncWriter<'b, W> {
             Compression::Zstd => CompressedAsyncWriter::Zstd(write::ZstdEncoder::new(ShutdownIgnoredWriter(writer))),
             #[cfg(feature = "xz")]
             Compression::Xz => CompressedAsyncWriter::Xz(write::XzEncoder::new(ShutdownIgnoredWriter(writer))),
-        }
+        })
     }
 
     pub fn into_inner(self) -> &'b mut AsyncOffsetWriter<W> {

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -51,6 +51,10 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
         writer: &'b mut ZipFileWriter<W>,
         mut entry: ZipEntry,
     ) -> Result<EntryStreamWriter<'b, W>> {
+        if writer.force_no_zip64 && writer.cd_entries.len() >= NON_ZIP64_MAX_NUM_FILES as usize {
+            return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+        }
+
         let lfh_offset = writer.writer.offset();
         let lfh = EntryStreamWriter::write_lfh(writer, &mut entry).await?;
         let data_offset = writer.writer.offset();
@@ -240,11 +244,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
         };
 
         self.cd_entries.push(CentralDirectoryEntry { header: cdh, entry: self.entry });
-        // Ensure that we can fit this many files in this archive if forcing no zip64
+        // Mark the archive as Zip64 once the central directory no longer fits in the legacy count field.
         if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
-            if self.force_no_zip64 {
-                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
-            }
             if !*self.is_zip64 {
                 *self.is_zip64 = true;
             }

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -55,6 +55,11 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
             return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
         }
 
+        #[cfg(feature = "deflate64")]
+        if matches!(entry.compression(), crate::Compression::Deflate64) {
+            return Err(ZipError::FeatureNotSupported("Deflate64 writing"));
+        }
+
         let lfh_offset = writer.writer.offset();
         let lfh = EntryStreamWriter::write_lfh(writer, &mut entry).await?;
         let data_offset = writer.writer.offset();
@@ -62,7 +67,7 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
 
         let cd_entries = &mut writer.cd_entries;
         let is_zip64 = &mut writer.is_zip64;
-        let writer = AsyncOffsetWriter::new(CompressedAsyncWriter::from_raw(&mut writer.writer, entry.compression()));
+        let writer = AsyncOffsetWriter::new(CompressedAsyncWriter::from_raw(&mut writer.writer, entry.compression())?);
 
         Ok(EntryStreamWriter {
             writer,

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::base::write::compressed_writer::CompressedAsyncWriter;
+use crate::base::write::get_or_put_info_zip_unicode_comment_extra_field_mut;
+use crate::base::write::get_or_put_info_zip_unicode_path_extra_field_mut;
+use crate::base::write::io::offset::AsyncOffsetWriter;
+use crate::base::write::CentralDirectoryEntry;
+use crate::base::write::ZipFileWriter;
+use crate::entry::ZipEntry;
+use crate::error::{Result, Zip64ErrorCase, ZipError};
+use crate::spec::extra_field::ExtraFieldAsBytes;
+use crate::spec::header::InfoZipUnicodeCommentExtraField;
+use crate::spec::header::InfoZipUnicodePathExtraField;
+use crate::spec::header::{
+    CentralDirectoryRecord, ExtraField, GeneralPurposeFlag, LocalFileHeader, Zip64ExtendedInformationExtraField,
+};
+use crate::string::StringEncoding;
+
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::base::read::get_zip64_extra_field_mut;
+use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
+use crc32fast::Hasher;
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+
+/// An entry writer which supports the streaming of data (ie. the writing of unknown size or data at runtime).
+///
+/// # Note
+/// - This writer cannot be manually constructed; instead, use [`ZipFileWriter::write_entry_stream()`].
+/// - [`EntryStreamWriter::close()`] must be called before a stream writer goes out of scope.
+/// - Utilities for working with [`AsyncWrite`] values are provided by [`AsyncWriteExt`].
+pub struct EntryStreamWriter<'b, W: AsyncWrite + Unpin> {
+    writer: AsyncOffsetWriter<CompressedAsyncWriter<'b, W>>,
+    cd_entries: &'b mut Vec<CentralDirectoryEntry>,
+    entry: ZipEntry,
+    hasher: Hasher,
+    lfh: LocalFileHeader,
+    lfh_offset: u64,
+    data_offset: u64,
+    force_no_zip64: bool,
+    /// To write back to the original writer if zip64 is required.
+    is_zip64: &'b mut bool,
+}
+
+impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
+    pub(crate) async fn from_raw(
+        writer: &'b mut ZipFileWriter<W>,
+        mut entry: ZipEntry,
+    ) -> Result<EntryStreamWriter<'b, W>> {
+        let lfh_offset = writer.writer.offset();
+        let lfh = EntryStreamWriter::write_lfh(writer, &mut entry).await?;
+        let data_offset = writer.writer.offset();
+        let force_no_zip64 = writer.force_no_zip64;
+
+        let cd_entries = &mut writer.cd_entries;
+        let is_zip64 = &mut writer.is_zip64;
+        let writer = AsyncOffsetWriter::new(CompressedAsyncWriter::from_raw(&mut writer.writer, entry.compression()));
+
+        Ok(EntryStreamWriter {
+            writer,
+            cd_entries,
+            entry,
+            lfh,
+            lfh_offset,
+            data_offset,
+            hasher: Hasher::new(),
+            force_no_zip64,
+            is_zip64,
+        })
+    }
+
+    async fn write_lfh(writer: &'b mut ZipFileWriter<W>, entry: &mut ZipEntry) -> Result<LocalFileHeader> {
+        // Always emit a zip64 extended field, even if we don't need it, because we *might* need it.
+        // If we are forcing no zip, we will have to error later if the file is too large.
+        let (lfh_compressed, lfh_uncompressed) = if !writer.force_no_zip64 {
+            if !writer.is_zip64 {
+                writer.is_zip64 = true;
+            }
+            entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformationExtraField {
+                uncompressed_size: Some(entry.uncompressed_size),
+                compressed_size: Some(entry.compressed_size),
+                relative_header_offset: None,
+                disk_start_number: None,
+            }));
+
+            (NON_ZIP64_MAX_SIZE, NON_ZIP64_MAX_SIZE)
+        } else {
+            if entry.compressed_size > NON_ZIP64_MAX_SIZE as u64 || entry.uncompressed_size > NON_ZIP64_MAX_SIZE as u64
+            {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+
+            (entry.compressed_size as u32, entry.uncompressed_size as u32)
+        };
+
+        let utf8_without_alternative =
+            entry.filename().is_utf8_without_alternative() && entry.comment().is_utf8_without_alternative();
+        if !utf8_without_alternative {
+            if matches!(entry.filename().encoding(), StringEncoding::Utf8) {
+                let u_file_name = entry.filename().as_bytes().to_vec();
+                if !u_file_name.is_empty() {
+                    let basic_crc32 =
+                        crc32fast::hash(entry.filename().alternative().unwrap_or_else(|| entry.filename().as_bytes()));
+                    let upath_field = get_or_put_info_zip_unicode_path_extra_field_mut(entry.extra_fields.as_mut());
+                    if let InfoZipUnicodePathExtraField::V1 { crc32, unicode } = upath_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_file_name;
+                    }
+                }
+            }
+            if matches!(entry.comment().encoding(), StringEncoding::Utf8) {
+                let u_comment = entry.comment().as_bytes().to_vec();
+                if !u_comment.is_empty() {
+                    let basic_crc32 =
+                        crc32fast::hash(entry.comment().alternative().unwrap_or_else(|| entry.comment().as_bytes()));
+                    let ucom_field = get_or_put_info_zip_unicode_comment_extra_field_mut(entry.extra_fields.as_mut());
+                    if let InfoZipUnicodeCommentExtraField::V1 { crc32, unicode } = ucom_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_comment;
+                    }
+                }
+            }
+        }
+
+        let filename_basic = entry.filename().alternative().unwrap_or_else(|| entry.filename().as_bytes());
+
+        let lfh = LocalFileHeader {
+            compressed_size: lfh_compressed,
+            uncompressed_size: lfh_uncompressed,
+            compression: entry.compression().into(),
+            crc: entry.crc32,
+            extra_field_length: entry
+                .extra_fields()
+                .count_bytes()
+                .try_into()
+                .map_err(|_| ZipError::ExtraFieldTooLarge)?,
+            file_name_length: filename_basic.len().try_into().map_err(|_| ZipError::FileNameTooLarge)?,
+            mod_time: entry.last_modification_date().time,
+            mod_date: entry.last_modification_date().date,
+            version: crate::spec::version::as_needed_to_extract(entry),
+            flags: GeneralPurposeFlag {
+                data_descriptor: true,
+                encrypted: false,
+                filename_unicode: utf8_without_alternative,
+            },
+        };
+
+        writer.writer.write_all(&crate::spec::consts::LFH_SIGNATURE.to_le_bytes()).await?;
+        writer.writer.write_all(&lfh.as_slice()).await?;
+        writer.writer.write_all(filename_basic).await?;
+        writer.writer.write_all(&entry.extra_fields().as_bytes()).await?;
+
+        Ok(lfh)
+    }
+
+    /// Consumes this entry writer and completes all closing tasks.
+    ///
+    /// This includes:
+    /// - Finalising the CRC32 hash value for the written data.
+    /// - Calculating the compressed and uncompressed byte sizes.
+    /// - Constructing a central directory header.
+    /// - Pushing that central directory header to the [`ZipFileWriter`]'s store.
+    ///
+    /// Failure to call this function before going out of scope would result in a corrupted ZIP file.
+    pub async fn close(mut self) -> Result<()> {
+        self.writer.close().await?;
+
+        let crc = self.hasher.finalize();
+        let uncompressed_size = self.writer.offset();
+        let inner_writer = self.writer.into_inner().into_inner();
+        let compressed_size = inner_writer.offset() - self.data_offset;
+
+        let (cdr_compressed_size, cdr_uncompressed_size, lh_offset) = if self.force_no_zip64 {
+            if uncompressed_size > NON_ZIP64_MAX_SIZE as u64
+                || compressed_size > NON_ZIP64_MAX_SIZE as u64
+                || self.lfh_offset > NON_ZIP64_MAX_SIZE as u64
+            {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            (uncompressed_size as u32, compressed_size as u32, self.lfh_offset as u32)
+        } else {
+            // When streaming an entry, we are always using a zip64 field.
+            match get_zip64_extra_field_mut(&mut self.entry.extra_fields) {
+                // This case shouldn't be necessary but is included for completeness.
+                None => {
+                    self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(
+                        Zip64ExtendedInformationExtraField {
+                            uncompressed_size: Some(uncompressed_size),
+                            compressed_size: Some(compressed_size),
+                            relative_header_offset: Some(self.lfh_offset),
+                            disk_start_number: None,
+                        },
+                    ));
+                }
+                Some(zip64) => {
+                    zip64.uncompressed_size = Some(uncompressed_size);
+                    zip64.compressed_size = Some(compressed_size);
+                    zip64.relative_header_offset = Some(self.lfh_offset);
+                }
+            }
+            self.lfh.extra_field_length =
+                self.entry.extra_fields().count_bytes().try_into().map_err(|_| ZipError::ExtraFieldTooLarge)?;
+
+            (NON_ZIP64_MAX_SIZE, NON_ZIP64_MAX_SIZE, NON_ZIP64_MAX_SIZE)
+        };
+
+        inner_writer.write_all(&crate::spec::consts::DATA_DESCRIPTOR_SIGNATURE.to_le_bytes()).await?;
+        inner_writer.write_all(&crc.to_le_bytes()).await?;
+        inner_writer.write_all(&cdr_compressed_size.to_le_bytes()).await?;
+        inner_writer.write_all(&cdr_uncompressed_size.to_le_bytes()).await?;
+
+        let comment_basic = self.entry.comment().alternative().unwrap_or_else(|| self.entry.comment().as_bytes());
+
+        let cdh = CentralDirectoryRecord {
+            compressed_size: cdr_compressed_size,
+            uncompressed_size: cdr_uncompressed_size,
+            crc,
+            v_made_by: crate::spec::version::as_made_by(),
+            v_needed: self.lfh.version,
+            compression: self.lfh.compression,
+            extra_field_length: self.lfh.extra_field_length,
+            file_name_length: self.lfh.file_name_length,
+            file_comment_length: comment_basic.len().try_into().map_err(|_| ZipError::CommentTooLarge)?,
+            mod_time: self.lfh.mod_time,
+            mod_date: self.lfh.mod_date,
+            flags: self.lfh.flags,
+            disk_start: 0,
+            inter_attr: self.entry.internal_file_attribute(),
+            exter_attr: self.entry.external_file_attribute(),
+            lh_offset,
+        };
+
+        self.cd_entries.push(CentralDirectoryEntry { header: cdh, entry: self.entry });
+        // Ensure that we can fit this many files in this archive if forcing no zip64
+        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
+            if self.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+            }
+            if !*self.is_zip64 {
+                *self.is_zip64 = true;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, W: AsyncWrite + Unpin> AsyncWrite for EntryStreamWriter<'a, W> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        let poll = Pin::new(&mut self.writer).poll_write(cx, buf);
+
+        if let Poll::Ready(Ok(written)) = poll {
+            self.hasher.update(&buf[0..written]);
+        }
+
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(&mut self.writer).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(&mut self.writer).poll_close(cx)
+    }
+}

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -9,6 +9,7 @@ use crate::base::write::CentralDirectoryEntry;
 use crate::base::write::ZipFileWriter;
 use crate::entry::ZipEntry;
 use crate::error::{Result, Zip64ErrorCase, ZipError};
+use crate::spec::data_descriptor::{DataDescriptor, Zip64DataDescriptor};
 use crate::spec::extra_field::ExtraFieldAsBytes;
 use crate::spec::header::InfoZipUnicodeCommentExtraField;
 use crate::spec::header::InfoZipUnicodePathExtraField;
@@ -208,9 +209,14 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
         };
 
         inner_writer.write_all(&crate::spec::consts::DATA_DESCRIPTOR_SIGNATURE.to_le_bytes()).await?;
-        inner_writer.write_all(&crc.to_le_bytes()).await?;
-        inner_writer.write_all(&cdr_compressed_size.to_le_bytes()).await?;
-        inner_writer.write_all(&cdr_uncompressed_size.to_le_bytes()).await?;
+        if self.force_no_zip64 {
+            let descriptor =
+                DataDescriptor { crc, compressed_size: cdr_compressed_size, uncompressed_size: cdr_uncompressed_size };
+            inner_writer.write_all(&descriptor.as_bytes()).await?;
+        } else {
+            let descriptor = Zip64DataDescriptor { crc, compressed_size, uncompressed_size };
+            inner_writer.write_all(&descriptor.as_bytes()).await?;
+        }
 
         let comment_basic = self.entry.comment().alternative().unwrap_or_else(|| self.entry.comment().as_bytes());
 

--- a/src/base/write/entry_stream.rs
+++ b/src/base/write/entry_stream.rs
@@ -245,10 +245,8 @@ impl<'b, W: AsyncWrite + Unpin> EntryStreamWriter<'b, W> {
 
         self.cd_entries.push(CentralDirectoryEntry { header: cdh, entry: self.entry });
         // Mark the archive as Zip64 once the central directory no longer fits in the legacy count field.
-        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
-            if !*self.is_zip64 {
-                *self.is_zip64 = true;
-            }
+        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize && !*self.is_zip64 {
+            *self.is_zip64 = true;
         }
 
         Ok(())

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -1,0 +1,259 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::base::write::get_or_put_info_zip_unicode_comment_extra_field_mut;
+use crate::base::write::get_or_put_info_zip_unicode_path_extra_field_mut;
+use crate::base::write::{CentralDirectoryEntry, ZipFileWriter};
+use crate::entry::ZipEntry;
+use crate::error::{Result, Zip64ErrorCase, ZipError};
+use crate::spec::extra_field::Zip64ExtendedInformationExtraFieldBuilder;
+use crate::spec::header::{InfoZipUnicodeCommentExtraField, InfoZipUnicodePathExtraField};
+use crate::spec::{
+    extra_field::ExtraFieldAsBytes,
+    header::{CentralDirectoryRecord, ExtraField, GeneralPurposeFlag, LocalFileHeader},
+    Compression,
+};
+use crate::StringEncoding;
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+use futures_lite::io::Cursor;
+
+use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+use async_compression::futures::write;
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+
+pub struct EntryWholeWriter<'b, 'c, W: AsyncWrite + Unpin> {
+    writer: &'b mut ZipFileWriter<W>,
+    entry: ZipEntry,
+    data: &'c [u8],
+}
+
+impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
+    pub fn from_raw(writer: &'b mut ZipFileWriter<W>, entry: ZipEntry, data: &'c [u8]) -> Self {
+        Self { writer, entry, data }
+    }
+
+    pub async fn write(mut self) -> Result<()> {
+        let mut _compressed_data: Option<Vec<u8>> = None;
+        let compressed_data = match self.entry.compression() {
+            Compression::Stored => self.data,
+            #[cfg(any(
+                feature = "deflate",
+                feature = "bzip2",
+                feature = "zstd",
+                feature = "lzma",
+                feature = "xz",
+                feature = "deflate64"
+            ))]
+            _ => {
+                _compressed_data =
+                    Some(compress(self.entry.compression(), self.data, self.entry.compression_level).await);
+                _compressed_data.as_ref().unwrap()
+            }
+        };
+
+        let mut zip64_extra_field_builder = None;
+
+        let (lfh_uncompressed_size, lfh_compressed_size) = if self.data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
+            || compressed_data.len() as u64 > NON_ZIP64_MAX_SIZE as u64
+        {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
+            zip64_extra_field_builder = Some(
+                Zip64ExtendedInformationExtraFieldBuilder::new()
+                    .sizes(compressed_data.len() as u64, self.data.len() as u64),
+            );
+            (NON_ZIP64_MAX_SIZE, NON_ZIP64_MAX_SIZE)
+        } else {
+            (self.data.len() as u32, compressed_data.len() as u32)
+        };
+
+        let lh_offset = if self.writer.writer.offset() > NON_ZIP64_MAX_SIZE as u64 {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
+
+            if let Some(zip64_extra_field) = zip64_extra_field_builder {
+                zip64_extra_field_builder = Some(zip64_extra_field.relative_header_offset(self.writer.writer.offset()));
+            } else {
+                zip64_extra_field_builder = Some(
+                    Zip64ExtendedInformationExtraFieldBuilder::new()
+                        .relative_header_offset(self.writer.writer.offset()),
+                );
+            }
+            NON_ZIP64_MAX_SIZE
+        } else {
+            self.writer.writer.offset() as u32
+        };
+
+        if let Some(builder) = zip64_extra_field_builder {
+            if !builder.eof_only() {
+                self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(builder.build()?));
+                zip64_extra_field_builder = None;
+            } else {
+                zip64_extra_field_builder = Some(builder);
+            }
+        }
+
+        let utf8_without_alternative =
+            self.entry.filename().is_utf8_without_alternative() && self.entry.comment().is_utf8_without_alternative();
+        if !utf8_without_alternative {
+            if matches!(self.entry.filename().encoding(), StringEncoding::Utf8) {
+                let u_file_name = self.entry.filename().as_bytes().to_vec();
+                if !u_file_name.is_empty() {
+                    let basic_crc32 = crc32fast::hash(
+                        self.entry.filename().alternative().unwrap_or_else(|| self.entry.filename().as_bytes()),
+                    );
+                    let upath_field =
+                        get_or_put_info_zip_unicode_path_extra_field_mut(self.entry.extra_fields.as_mut());
+                    if let InfoZipUnicodePathExtraField::V1 { crc32, unicode } = upath_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_file_name;
+                    }
+                }
+            }
+            if matches!(self.entry.comment().encoding(), StringEncoding::Utf8) {
+                let u_comment = self.entry.comment().as_bytes().to_vec();
+                if !u_comment.is_empty() {
+                    let basic_crc32 = crc32fast::hash(
+                        self.entry.comment().alternative().unwrap_or_else(|| self.entry.comment().as_bytes()),
+                    );
+                    let ucom_field =
+                        get_or_put_info_zip_unicode_comment_extra_field_mut(self.entry.extra_fields.as_mut());
+                    if let InfoZipUnicodeCommentExtraField::V1 { crc32, unicode } = ucom_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_comment;
+                    }
+                }
+            }
+        }
+
+        let filename_basic = self.entry.filename().alternative().unwrap_or_else(|| self.entry.filename().as_bytes());
+        let comment_basic = self.entry.comment().alternative().unwrap_or_else(|| self.entry.comment().as_bytes());
+
+        let lf_header = LocalFileHeader {
+            compressed_size: lfh_compressed_size,
+            uncompressed_size: lfh_uncompressed_size,
+            compression: self.entry.compression().into(),
+            crc: crc32fast::hash(self.data),
+            extra_field_length: self
+                .entry
+                .extra_fields()
+                .count_bytes()
+                .try_into()
+                .map_err(|_| ZipError::ExtraFieldTooLarge)?,
+            file_name_length: filename_basic.len().try_into().map_err(|_| ZipError::FileNameTooLarge)?,
+            mod_time: self.entry.last_modification_date().time,
+            mod_date: self.entry.last_modification_date().date,
+            version: crate::spec::version::as_needed_to_extract(&self.entry),
+            flags: GeneralPurposeFlag {
+                data_descriptor: false,
+                encrypted: false,
+                filename_unicode: utf8_without_alternative,
+            },
+        };
+
+        let mut header = CentralDirectoryRecord {
+            v_made_by: crate::spec::version::as_made_by(),
+            v_needed: lf_header.version,
+            compressed_size: lf_header.compressed_size,
+            uncompressed_size: lf_header.uncompressed_size,
+            compression: lf_header.compression,
+            crc: lf_header.crc,
+            extra_field_length: lf_header.extra_field_length,
+            file_name_length: lf_header.file_name_length,
+            file_comment_length: comment_basic.len().try_into().map_err(|_| ZipError::CommentTooLarge)?,
+            mod_time: lf_header.mod_time,
+            mod_date: lf_header.mod_date,
+            flags: lf_header.flags,
+            disk_start: 0,
+            inter_attr: self.entry.internal_file_attribute(),
+            exter_attr: self.entry.external_file_attribute(),
+            lh_offset,
+        };
+
+        self.writer.writer.write_all(&crate::spec::consts::LFH_SIGNATURE.to_le_bytes()).await?;
+        self.writer.writer.write_all(&lf_header.as_slice()).await?;
+        self.writer.writer.write_all(filename_basic).await?;
+        self.writer.writer.write_all(&self.entry.extra_fields().as_bytes()).await?;
+        self.writer.writer.write_all(compressed_data).await?;
+
+        if let Some(builder) = zip64_extra_field_builder {
+            self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(builder.build()?));
+            header.extra_field_length =
+                self.entry.extra_fields().count_bytes().try_into().map_err(|_| ZipError::ExtraFieldTooLarge)?;
+        }
+
+        self.writer.cd_entries.push(CentralDirectoryEntry { header, entry: self.entry });
+        // Ensure that we can fit this many files in this archive if forcing no zip64
+        if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
+            if self.writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+            }
+            if !self.writer.is_zip64 {
+                self.writer.is_zip64 = true;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(any(
+    feature = "deflate",
+    feature = "bzip2",
+    feature = "zstd",
+    feature = "lzma",
+    feature = "xz",
+    feature = "deflate64"
+))]
+async fn compress(compression: Compression, data: &[u8], level: async_compression::Level) -> Vec<u8> {
+    // TODO: Reduce reallocations of Vec by making a lower-bound estimate of the length reduction and
+    // pre-initialising the Vec to that length. Then truncate() to the actual number of bytes written.
+    match compression {
+        #[cfg(feature = "deflate")]
+        Compression::Deflate => {
+            let mut writer = write::DeflateEncoder::with_quality(Cursor::new(Vec::new()), level);
+            writer.write_all(data).await.unwrap();
+            writer.close().await.unwrap();
+            writer.into_inner().into_inner()
+        }
+        #[cfg(feature = "deflate64")]
+        Compression::Deflate64 => panic!("compressing deflate64 is not supported"),
+        #[cfg(feature = "bzip2")]
+        Compression::Bz => {
+            let mut writer = write::BzEncoder::with_quality(Cursor::new(Vec::new()), level);
+            writer.write_all(data).await.unwrap();
+            writer.close().await.unwrap();
+            writer.into_inner().into_inner()
+        }
+        #[cfg(feature = "lzma")]
+        Compression::Lzma => {
+            let mut writer = write::LzmaEncoder::with_quality(Cursor::new(Vec::new()), level);
+            writer.write_all(data).await.unwrap();
+            writer.close().await.unwrap();
+            writer.into_inner().into_inner()
+        }
+        #[cfg(feature = "xz")]
+        Compression::Xz => {
+            let mut writer = write::XzEncoder::with_quality(Cursor::new(Vec::new()), level);
+            writer.write_all(data).await.unwrap();
+            writer.close().await.unwrap();
+            writer.into_inner().into_inner()
+        }
+        #[cfg(feature = "zstd")]
+        Compression::Zstd => {
+            let mut writer = write::ZstdEncoder::with_quality(Cursor::new(Vec::new()), level);
+            writer.write_all(data).await.unwrap();
+            writer.close().await.unwrap();
+            writer.into_inner().into_inner()
+        }
+        _ => unreachable!(),
+    }
+}

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -197,10 +197,8 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
 
         self.writer.cd_entries.push(CentralDirectoryEntry { header, entry: self.entry });
         // Mark the archive as Zip64 once the central directory no longer fits in the legacy count field.
-        if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
-            if !self.writer.is_zip64 {
-                self.writer.is_zip64 = true;
-            }
+        if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize && !self.writer.is_zip64 {
+            self.writer.is_zip64 = true;
         }
         Ok(())
     }

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -41,17 +41,12 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
         let mut _compressed_data: Option<Vec<u8>> = None;
         let compressed_data = match self.entry.compression() {
             Compression::Stored => self.data,
-            #[cfg(any(
-                feature = "deflate",
-                feature = "bzip2",
-                feature = "zstd",
-                feature = "lzma",
-                feature = "xz",
-                feature = "deflate64"
-            ))]
+            #[cfg(feature = "deflate64")]
+            Compression::Deflate64 => return Err(ZipError::FeatureNotSupported("Deflate64 writing")),
+            #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
             _ => {
                 _compressed_data =
-                    Some(compress(self.entry.compression(), self.data, self.entry.compression_level).await);
+                    Some(compress(self.entry.compression(), self.data, self.entry.compression_level).await?);
                 _compressed_data.as_ref().unwrap()
             }
         };
@@ -204,18 +199,11 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
     }
 }
 
-#[cfg(any(
-    feature = "deflate",
-    feature = "bzip2",
-    feature = "zstd",
-    feature = "lzma",
-    feature = "xz",
-    feature = "deflate64"
-))]
-async fn compress(compression: Compression, data: &[u8], level: async_compression::Level) -> Vec<u8> {
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+async fn compress(compression: Compression, data: &[u8], level: async_compression::Level) -> Result<Vec<u8>> {
     // TODO: Reduce reallocations of Vec by making a lower-bound estimate of the length reduction and
     // pre-initialising the Vec to that length. Then truncate() to the actual number of bytes written.
-    match compression {
+    Ok(match compression {
         #[cfg(feature = "deflate")]
         Compression::Deflate => {
             let mut writer = write::DeflateEncoder::with_quality(Cursor::new(Vec::new()), level);
@@ -223,8 +211,6 @@ async fn compress(compression: Compression, data: &[u8], level: async_compressio
             writer.close().await.unwrap();
             writer.into_inner().into_inner()
         }
-        #[cfg(feature = "deflate64")]
-        Compression::Deflate64 => panic!("compressing deflate64 is not supported"),
         #[cfg(feature = "bzip2")]
         Compression::Bz => {
             let mut writer = write::BzEncoder::with_quality(Cursor::new(Vec::new()), level);
@@ -254,5 +240,5 @@ async fn compress(compression: Compression, data: &[u8], level: async_compressio
             writer.into_inner().into_inner()
         }
         _ => unreachable!(),
-    }
+    })
 }

--- a/src/base/write/entry_whole.rs
+++ b/src/base/write/entry_whole.rs
@@ -34,6 +34,10 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
     }
 
     pub async fn write(mut self) -> Result<()> {
+        if self.writer.force_no_zip64 && self.writer.cd_entries.len() >= NON_ZIP64_MAX_NUM_FILES as usize {
+            return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+        }
+
         let mut _compressed_data: Option<Vec<u8>> = None;
         let compressed_data = match self.entry.compression() {
             Compression::Stored => self.data,
@@ -192,11 +196,8 @@ impl<'b, 'c, W: AsyncWrite + Unpin> EntryWholeWriter<'b, 'c, W> {
         }
 
         self.writer.cd_entries.push(CentralDirectoryEntry { header, entry: self.entry });
-        // Ensure that we can fit this many files in this archive if forcing no zip64
+        // Mark the archive as Zip64 once the central directory no longer fits in the legacy count field.
         if self.writer.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize {
-            if self.writer.force_no_zip64 {
-                return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
-            }
             if !self.writer.is_zip64 {
                 self.writer.is_zip64 = true;
             }

--- a/src/base/write/io/mod.rs
+++ b/src/base/write/io/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+pub(crate) mod offset;

--- a/src/base/write/io/offset.rs
+++ b/src/base/write/io/offset.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use std::io::{Error, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_lite::io::AsyncWrite;
+use pin_project::pin_project;
+
+/// A wrapper around an [`AsyncWrite`] implementation which tracks the current byte offset.
+#[pin_project(project = OffsetWriterProj)]
+pub struct AsyncOffsetWriter<W> {
+    #[pin]
+    inner: W,
+    offset: u64,
+}
+
+impl<W> AsyncOffsetWriter<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    /// Constructs a new wrapper from an inner [`AsyncWrite`] writer.
+    pub fn new(inner: W) -> Self {
+        Self { inner, offset: 0 }
+    }
+
+    /// Returns the current byte offset.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    /// Consumes this wrapper and returns the inner [`AsyncWrite`] writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+}
+
+impl<W> AsyncWrite for AsyncOffsetWriter<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        let this = self.project();
+        let poll = this.inner.poll_write(cx, buf);
+
+        if let Poll::Ready(Ok(inner)) = &poll {
+            *this.offset += *inner as u64;
+        }
+
+        poll
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Error>> {
+        self.project().inner.poll_close(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize, Error>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+}

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -1,0 +1,290 @@
+// Copyright (c) 2021-2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+//! A module which supports writing ZIP files.
+//!
+//! # Example
+//! ### Whole data (u8 slice)
+//! ```no_run
+//! # #[cfg(feature = "deflate")]
+//! # {
+//! # use async_zip::{Compression, ZipEntryBuilder, base::write::ZipFileWriter};
+//! # use async_zip::error::ZipError;
+//! #
+//! # async fn run() -> Result<(), ZipError> {
+//! let mut writer = ZipFileWriter::new(Vec::<u8>::new());
+//!
+//! let data = b"This is an example file.";
+//! let opts = ZipEntryBuilder::new(String::from("foo.txt").into(), Compression::Deflate);
+//!
+//! writer.write_entry_whole(opts, data).await?;
+//! writer.close().await?;
+//! #   Ok(())
+//! # }
+//! # }
+//! ```
+//! ### Stream data (unknown size & data)
+//! ```no_run
+//! # #[cfg(feature = "deflate")]
+//! # {
+//! # use async_zip::{Compression, ZipEntryBuilder, base::write::ZipFileWriter};
+//! # use std::io::Cursor;
+//! # use async_zip::error::ZipError;
+//! # use futures_lite::io::AsyncWriteExt;
+//! # use tokio_util::compat::TokioAsyncWriteCompatExt;
+//! #
+//! # async fn run() -> Result<(), ZipError> {
+//! let mut writer = ZipFileWriter::new(Vec::<u8>::new());
+//!
+//! let data = b"This is an example file.";
+//! let opts = ZipEntryBuilder::new(String::from("bar.txt").into(), Compression::Deflate);
+//!
+//! let mut entry_writer = writer.write_entry_stream(opts).await?;
+//! entry_writer.write_all(data).await.unwrap();
+//!
+//! entry_writer.close().await?;
+//! writer.close().await?;
+//! #   Ok(())
+//! # }
+//! # }
+//! ```
+
+pub(crate) mod compressed_writer;
+pub(crate) mod entry_stream;
+pub(crate) mod entry_whole;
+pub(crate) mod io;
+
+pub use entry_stream::EntryStreamWriter;
+
+#[cfg(feature = "tokio")]
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+
+use crate::entry::ZipEntry;
+use crate::error::Result;
+use crate::spec::extra_field::ExtraFieldAsBytes;
+use crate::spec::header::{
+    CentralDirectoryRecord, EndOfCentralDirectoryHeader, ExtraField, InfoZipUnicodeCommentExtraField,
+    InfoZipUnicodePathExtraField, Zip64EndOfCentralDirectoryLocator, Zip64EndOfCentralDirectoryRecord,
+};
+
+#[cfg(feature = "tokio")]
+use crate::tokio::write::ZipFileWriter as TokioZipFileWriter;
+
+use entry_whole::EntryWholeWriter;
+use io::offset::AsyncOffsetWriter;
+
+use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+
+pub(crate) struct CentralDirectoryEntry {
+    pub header: CentralDirectoryRecord,
+    pub entry: ZipEntry,
+}
+
+/// A ZIP file writer which acts over AsyncWrite implementers.
+///
+/// # Note
+/// - [`ZipFileWriter::close()`] must be called before a stream writer goes out of scope.
+pub struct ZipFileWriter<W> {
+    pub(crate) writer: AsyncOffsetWriter<W>,
+    pub(crate) cd_entries: Vec<CentralDirectoryEntry>,
+    /// If true, will error if a Zip64 struct must be written.
+    force_no_zip64: bool,
+    /// Whether to write Zip64 end of directory structs.
+    pub(crate) is_zip64: bool,
+    comment_opt: Option<String>,
+}
+
+impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
+    /// Construct a new ZIP file writer from a mutable reference to a writer.
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer: AsyncOffsetWriter::new(writer),
+            cd_entries: Vec::new(),
+            comment_opt: None,
+            is_zip64: false,
+            force_no_zip64: false,
+        }
+    }
+
+    /// Force the ZIP writer to operate in non-ZIP64 mode.
+    /// If any files would need ZIP64, an error will be raised.
+    pub fn force_no_zip64(mut self) -> Self {
+        self.force_no_zip64 = true;
+        self
+    }
+
+    /// Force the ZIP writer to emit Zip64 structs at the end of the archive.
+    /// Zip64 extended fields will only be written if needed.
+    pub fn force_zip64(mut self) -> Self {
+        self.is_zip64 = true;
+        self
+    }
+
+    /// Write a new ZIP entry of known size and data.
+    pub async fn write_entry_whole<E: Into<ZipEntry>>(&mut self, entry: E, data: &[u8]) -> Result<()> {
+        EntryWholeWriter::from_raw(self, entry.into(), data).write().await
+    }
+
+    /// Write an entry of unknown size and data via streaming (ie. using a data descriptor).
+    /// The generated Local File Header will be invalid, with no compressed size, uncompressed size,
+    /// and a null CRC. This might cause problems with the destination reader.
+    pub async fn write_entry_stream<E: Into<ZipEntry>>(&mut self, entry: E) -> Result<EntryStreamWriter<'_, W>> {
+        EntryStreamWriter::from_raw(self, entry.into()).await
+    }
+
+    /// Set the ZIP file comment.
+    pub fn comment(&mut self, comment: String) {
+        self.comment_opt = Some(comment);
+    }
+
+    /// Returns a mutable reference to the inner writer.
+    ///
+    /// Care should be taken when using this inner writer as doing so may invalidate internal state of this writer.
+    pub fn inner_mut(&mut self) -> &mut W {
+        self.writer.inner_mut()
+    }
+
+    /// Consumes this ZIP writer and completes all closing tasks.
+    ///
+    /// This includes:
+    /// - Writing all central directory headers.
+    /// - Writing the end of central directory header.
+    /// - Writing the file comment.
+    ///
+    /// Failure to call this function before going out of scope would result in a corrupted ZIP file.
+    pub async fn close(mut self) -> Result<W> {
+        let cd_offset = self.writer.offset();
+
+        for entry in &self.cd_entries {
+            let filename_basic =
+                entry.entry.filename().alternative().unwrap_or_else(|| entry.entry.filename().as_bytes());
+            let comment_basic = entry.entry.comment().alternative().unwrap_or_else(|| entry.entry.comment().as_bytes());
+
+            self.writer.write_all(&crate::spec::consts::CDH_SIGNATURE.to_le_bytes()).await?;
+            self.writer.write_all(&entry.header.as_slice()).await?;
+            self.writer.write_all(filename_basic).await?;
+            self.writer.write_all(&entry.entry.extra_fields().as_bytes()).await?;
+            self.writer.write_all(comment_basic).await?;
+        }
+
+        let central_directory_size = self.writer.offset() - cd_offset;
+        let central_directory_size_u32 = if central_directory_size > NON_ZIP64_MAX_SIZE as u64 {
+            NON_ZIP64_MAX_SIZE
+        } else {
+            central_directory_size as u32
+        };
+        let num_entries_in_directory = self.cd_entries.len() as u64;
+        let num_entries_in_directory_u16 = if num_entries_in_directory > NON_ZIP64_MAX_NUM_FILES as u64 {
+            NON_ZIP64_MAX_NUM_FILES
+        } else {
+            num_entries_in_directory as u16
+        };
+        let cd_offset_u32 = if cd_offset > NON_ZIP64_MAX_SIZE as u64 {
+            if self.force_no_zip64 {
+                return Err(crate::error::ZipError::Zip64Needed(crate::error::Zip64ErrorCase::LargeFile));
+            } else {
+                self.is_zip64 = true;
+            }
+            NON_ZIP64_MAX_SIZE
+        } else {
+            cd_offset as u32
+        };
+
+        // Add the zip64 EOCDR and EOCDL if we are in zip64 mode.
+        if self.is_zip64 {
+            let eocdr_offset = self.writer.offset();
+
+            let eocdr = Zip64EndOfCentralDirectoryRecord {
+                size_of_zip64_end_of_cd_record: 44,
+                version_made_by: crate::spec::version::as_made_by(),
+                version_needed_to_extract: 46,
+                disk_number: 0,
+                disk_number_start_of_cd: 0,
+                num_entries_in_directory_on_disk: num_entries_in_directory,
+                num_entries_in_directory,
+                directory_size: central_directory_size,
+                offset_of_start_of_directory: cd_offset,
+            };
+            self.writer.write_all(&crate::spec::consts::ZIP64_EOCDR_SIGNATURE.to_le_bytes()).await?;
+            self.writer.write_all(&eocdr.as_bytes()).await?;
+
+            let eocdl = Zip64EndOfCentralDirectoryLocator {
+                number_of_disk_with_start_of_zip64_end_of_central_directory: 0,
+                relative_offset: eocdr_offset,
+                total_number_of_disks: 1,
+            };
+            self.writer.write_all(&crate::spec::consts::ZIP64_EOCDL_SIGNATURE.to_le_bytes()).await?;
+            self.writer.write_all(&eocdl.as_bytes()).await?;
+        }
+
+        let header = EndOfCentralDirectoryHeader {
+            disk_num: 0,
+            start_cent_dir_disk: 0,
+            num_of_entries_disk: num_entries_in_directory_u16,
+            num_of_entries: num_entries_in_directory_u16,
+            size_cent_dir: central_directory_size_u32,
+            cent_dir_offset: cd_offset_u32,
+            file_comm_length: self.comment_opt.as_ref().map(|v| v.len() as u16).unwrap_or_default(),
+        };
+
+        self.writer.write_all(&crate::spec::consts::EOCDR_SIGNATURE.to_le_bytes()).await?;
+        self.writer.write_all(&header.as_slice()).await?;
+        if let Some(comment) = self.comment_opt {
+            self.writer.write_all(comment.as_bytes()).await?;
+        }
+
+        Ok(self.writer.into_inner())
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<W> ZipFileWriter<Compat<W>>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    /// Construct a new ZIP file writer from a mutable reference to a writer.
+    pub fn with_tokio(writer: W) -> TokioZipFileWriter<W> {
+        Self {
+            writer: AsyncOffsetWriter::new(writer.compat_write()),
+            cd_entries: Vec::new(),
+            comment_opt: None,
+            is_zip64: false,
+            force_no_zip64: false,
+        }
+    }
+}
+
+pub(crate) fn get_or_put_info_zip_unicode_path_extra_field_mut(
+    extra_fields: &mut Vec<ExtraField>,
+) -> &mut InfoZipUnicodePathExtraField {
+    if !extra_fields.iter().any(|field| matches!(field, ExtraField::InfoZipUnicodePath(_))) {
+        extra_fields
+            .push(ExtraField::InfoZipUnicodePath(InfoZipUnicodePathExtraField::V1 { crc32: 0, unicode: vec![] }));
+    }
+
+    for field in extra_fields.iter_mut() {
+        if let ExtraField::InfoZipUnicodePath(extra_field) = field {
+            return extra_field;
+        }
+    }
+
+    panic!("InfoZipUnicodePathExtraField not found after insertion")
+}
+
+pub(crate) fn get_or_put_info_zip_unicode_comment_extra_field_mut(
+    extra_fields: &mut Vec<ExtraField>,
+) -> &mut InfoZipUnicodeCommentExtraField {
+    if !extra_fields.iter().any(|field| matches!(field, ExtraField::InfoZipUnicodeComment(_))) {
+        extra_fields
+            .push(ExtraField::InfoZipUnicodeComment(InfoZipUnicodeCommentExtraField::V1 { crc32: 0, unicode: vec![] }));
+    }
+
+    for field in extra_fields.iter_mut() {
+        if let ExtraField::InfoZipUnicodeComment(extra_field) = field {
+            return extra_field;
+        }
+    }
+
+    panic!("InfoZipUnicodeCommentExtraField not found after insertion")
+}

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -176,11 +176,8 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
         }
 
         let central_directory_size = self.writer.offset() - cd_offset;
-        let central_directory_size_u32 = if central_directory_size > NON_ZIP64_MAX_SIZE as u64 {
-            NON_ZIP64_MAX_SIZE
-        } else {
-            central_directory_size as u32
-        };
+        let central_directory_size_u32 =
+            central_directory_size_field(central_directory_size, self.force_no_zip64, &mut self.is_zip64)?;
         let num_entries_in_directory = self.cd_entries.len() as u64;
         let num_entries_in_directory_u16 = if num_entries_in_directory > NON_ZIP64_MAX_NUM_FILES as u64 {
             NON_ZIP64_MAX_NUM_FILES
@@ -242,6 +239,22 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
         }
 
         Ok(self.writer.into_inner())
+    }
+}
+
+pub(crate) fn central_directory_size_field(
+    central_directory_size: u64,
+    force_no_zip64: bool,
+    is_zip64: &mut bool,
+) -> Result<u32> {
+    if central_directory_size > NON_ZIP64_MAX_SIZE as u64 {
+        if force_no_zip64 {
+            return Err(crate::error::ZipError::Zip64Needed(crate::error::Zip64ErrorCase::LargeFile));
+        }
+        *is_zip64 = true;
+        Ok(NON_ZIP64_MAX_SIZE)
+    } else {
+        Ok(central_directory_size as u32)
     }
 }
 

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -154,6 +154,13 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
     ///
     /// Failure to call this function before going out of scope would result in a corrupted ZIP file.
     pub async fn close(mut self) -> Result<W> {
+        let file_comment_length = self
+            .comment_opt
+            .as_ref()
+            .map(|comment| comment.len().try_into())
+            .transpose()
+            .map_err(|_| crate::error::ZipError::CommentTooLarge)?
+            .unwrap_or_default();
         let cd_offset = self.writer.offset();
 
         for entry in &self.cd_entries {
@@ -225,7 +232,7 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
             num_of_entries: num_entries_in_directory_u16,
             size_cent_dir: central_directory_size_u32,
             cent_dir_offset: cd_offset_u32,
-            file_comm_length: self.comment_opt.as_ref().map(|v| v.len() as u16).unwrap_or_default(),
+            file_comm_length: file_comment_length,
         };
 
         self.writer.write_all(&crate::spec::consts::EOCDR_SIGNATURE.to_le_bytes()).await?;

--- a/src/date/builder.rs
+++ b/src/date/builder.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::ZipDateTime;
+
+/// A builder for [`ZipDateTime`].
+pub struct ZipDateTimeBuilder(pub(crate) ZipDateTime);
+
+impl From<ZipDateTime> for ZipDateTimeBuilder {
+    fn from(date: ZipDateTime) -> Self {
+        Self(date)
+    }
+}
+
+impl Default for ZipDateTimeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ZipDateTimeBuilder {
+    /// Constructs a new builder which defines the raw underlying data of a ZIP entry.
+    pub fn new() -> Self {
+        Self(ZipDateTime { date: 0, time: 0 })
+    }
+
+    /// Sets the date and time's year.
+    pub fn year(mut self, year: i32) -> Self {
+        let year: u16 = (((year - 1980) << 9) & 0xFE00).try_into().unwrap();
+        self.0.date |= year;
+        self
+    }
+
+    /// Sets the date and time's month.
+    pub fn month(mut self, month: u32) -> Self {
+        let month: u16 = ((month << 5) & 0x1E0).try_into().unwrap();
+        self.0.date |= month;
+        self
+    }
+
+    /// Sets the date and time's day.
+    pub fn day(mut self, day: u32) -> Self {
+        let day: u16 = (day & 0x1F).try_into().unwrap();
+        self.0.date |= day;
+        self
+    }
+
+    /// Sets the date and time's hour.
+    pub fn hour(mut self, hour: u32) -> Self {
+        let hour: u16 = ((hour << 11) & 0xF800).try_into().unwrap();
+        self.0.time |= hour;
+        self
+    }
+
+    /// Sets the date and time's minute.
+    pub fn minute(mut self, minute: u32) -> Self {
+        let minute: u16 = ((minute << 5) & 0x7E0).try_into().unwrap();
+        self.0.time |= minute;
+        self
+    }
+
+    /// Sets the date and time's second.
+    ///
+    /// Note that MS-DOS has a maximum granularity of two seconds.
+    pub fn second(mut self, second: u32) -> Self {
+        let second: u16 = ((second >> 1) & 0x1F).try_into().unwrap();
+        self.0.time |= second;
+        self
+    }
+
+    /// Consumes this builder and returns a final [`ZipDateTime`].
+    ///
+    /// This is equivalent to:
+    /// ```
+    /// # use async_zip::{ZipDateTime, ZipDateTimeBuilder, Compression};
+    /// #
+    /// # let builder = ZipDateTimeBuilder::new().year(2024).month(3).day(2);
+    /// let date: ZipDateTime = builder.into();
+    /// ```
+    pub fn build(self) -> ZipDateTime {
+        self.into()
+    }
+}

--- a/src/date/mod.rs
+++ b/src/date/mod.rs
@@ -1,6 +1,13 @@
 // Copyright (c) 2021-2024 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+pub mod builder;
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, Datelike, LocalResult, TimeZone, Timelike, Utc};
+
+use self::builder::ZipDateTimeBuilder;
+
 // https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#446
 // https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-dosdatetimetovarianttime
 
@@ -42,5 +49,64 @@ impl ZipDateTime {
     /// Note that MS-DOS has a maximum granularity of two seconds.
     pub fn second(&self) -> u32 {
         ((self.time & 0x1F) << 1).into()
+    }
+
+    /// Constructs chrono's [`DateTime`] representation of this date & time.
+    ///
+    /// Note that this requires the `chrono` feature.
+    #[cfg(feature = "chrono")]
+    pub fn as_chrono(&self) -> LocalResult<DateTime<Utc>> {
+        self.into()
+    }
+
+    /// Constructs this date & time from chrono's [`DateTime`] representation.
+    ///
+    /// Note that this requires the `chrono` feature.
+    #[cfg(feature = "chrono")]
+    pub fn from_chrono(dt: &DateTime<Utc>) -> Self {
+        dt.into()
+    }
+}
+
+impl From<ZipDateTimeBuilder> for ZipDateTime {
+    fn from(builder: ZipDateTimeBuilder) -> Self {
+        builder.0
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<&DateTime<Utc>> for ZipDateTime {
+    fn from(value: &DateTime<Utc>) -> Self {
+        let mut builder = ZipDateTimeBuilder::new();
+
+        builder = builder.year(value.date_naive().year());
+        builder = builder.month(value.date_naive().month());
+        builder = builder.day(value.date_naive().day());
+        builder = builder.hour(value.time().hour());
+        builder = builder.minute(value.time().minute());
+        builder = builder.second(value.time().second());
+
+        builder.build()
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<&ZipDateTime> for LocalResult<DateTime<Utc>> {
+    fn from(value: &ZipDateTime) -> Self {
+        Utc.with_ymd_and_hms(value.year(), value.month(), value.day(), value.hour(), value.minute(), value.second())
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<DateTime<Utc>> for ZipDateTime {
+    fn from(value: DateTime<Utc>) -> Self {
+        (&value).into()
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<ZipDateTime> for LocalResult<DateTime<Utc>> {
+    fn from(value: ZipDateTime) -> Self {
+        (&value).into()
     }
 }

--- a/src/entry/builder.rs
+++ b/src/entry/builder.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::entry::ZipEntry;
+use crate::spec::{attribute::AttributeCompatibility, header::ExtraField, Compression};
+use crate::{date::ZipDateTime, string::ZipString};
+
+/// A builder for [`ZipEntry`].
+pub struct ZipEntryBuilder(pub(crate) ZipEntry);
+
+impl From<ZipEntry> for ZipEntryBuilder {
+    fn from(entry: ZipEntry) -> Self {
+        Self(entry)
+    }
+}
+
+impl ZipEntryBuilder {
+    /// Constructs a new builder which defines the raw underlying data of a ZIP entry.
+    ///
+    /// A filename and compression method are needed to construct the builder as minimal parameters.
+    pub fn new(filename: ZipString, compression: Compression) -> Self {
+        Self(ZipEntry::new(filename, compression))
+    }
+
+    /// Sets the entry's filename.
+    pub fn filename(mut self, filename: ZipString) -> Self {
+        self.0.filename = filename;
+        self
+    }
+
+    /// Sets the entry's compression method.
+    pub fn compression(mut self, compression: Compression) -> Self {
+        self.0.compression = compression;
+        self
+    }
+
+    /// Set a size hint for the file, to be written into the local file header.
+    /// Unlikely to be useful except for the case of streaming files to be Store'd.
+    /// This size hint does not affect the central directory, nor does it affect whole files.
+    pub fn size<N: Into<u64>, M: Into<u64>>(mut self, compressed_size: N, uncompressed_size: M) -> Self {
+        self.0.compressed_size = compressed_size.into();
+        self.0.uncompressed_size = uncompressed_size.into();
+        self
+    }
+
+    /// Set the deflate compression option.
+    ///
+    /// If the compression type isn't deflate, this option has no effect.
+    #[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+    pub fn deflate_option(mut self, option: crate::DeflateOption) -> Self {
+        self.0.compression_level = option.into_level();
+        self
+    }
+
+    /// Sets the entry's attribute host compatibility.
+    pub fn attribute_compatibility(mut self, compatibility: AttributeCompatibility) -> Self {
+        self.0.attribute_compatibility = compatibility;
+        self
+    }
+
+    /// Sets the entry's last modification date.
+    pub fn last_modification_date(mut self, date: ZipDateTime) -> Self {
+        self.0.last_modification_date = date;
+        self
+    }
+
+    /// Sets the entry's internal file attribute.
+    pub fn internal_file_attribute(mut self, attribute: u16) -> Self {
+        self.0.internal_file_attribute = attribute;
+        self
+    }
+
+    /// Sets the entry's external file attribute.
+    pub fn external_file_attribute(mut self, attribute: u32) -> Self {
+        self.0.external_file_attribute = attribute;
+        self
+    }
+
+    /// Sets the entry's extra field data.
+    pub fn extra_fields(mut self, field: Vec<ExtraField>) -> Self {
+        self.0.extra_fields = field;
+        self
+    }
+
+    /// Sets the entry's file comment.
+    pub fn comment(mut self, comment: ZipString) -> Self {
+        self.0.comment = comment;
+        self
+    }
+
+    /// Sets the entry's Unix permissions mode.
+    ///
+    /// If the attribute host compatibility isn't set to Unix, this will have no effect.
+    pub fn unix_permissions(mut self, mode: u16) -> Self {
+        if matches!(self.0.attribute_compatibility, AttributeCompatibility::Unix) {
+            self.0.external_file_attribute = (self.0.external_file_attribute & 0xFFFF) | (mode as u32) << 16;
+        }
+        self
+    }
+
+    /// Consumes this builder and returns a final [`ZipEntry`].
+    ///
+    /// This is equivalent to:
+    /// ```
+    /// # use async_zip::{ZipEntry, ZipEntryBuilder, Compression};
+    /// #
+    /// # let builder = ZipEntryBuilder::new(String::from("foo.bar").into(), Compression::Stored);
+    /// let entry: ZipEntry = builder.into();
+    /// ```
+    pub fn build(self) -> ZipEntry {
+        self.into()
+    }
+}

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -1,10 +1,13 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+pub mod builder;
+
 use std::ops::Deref;
 
 use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
+use crate::entry::builder::ZipEntryBuilder;
 use crate::error::{Result, ZipError};
 use crate::spec::{
     attribute::AttributeCompatibility,
@@ -15,6 +18,10 @@ use crate::spec::{
 use crate::{string::ZipString, ZipDateTime};
 
 /// An immutable store of data about a ZIP entry.
+///
+/// This type cannot be directly constructed so instead, the [`ZipEntryBuilder`] must be used. Internally this builder
+/// stores a [`ZipEntry`] so conversions between these two types via the [`From`] implementations will be
+/// non-allocating.
 #[derive(Clone, Debug)]
 pub struct ZipEntry {
     pub(crate) filename: ZipString,
@@ -41,7 +48,40 @@ pub struct ZipEntry {
     pub(crate) file_offset: u64,
 }
 
+impl From<ZipEntryBuilder> for ZipEntry {
+    fn from(builder: ZipEntryBuilder) -> Self {
+        builder.0
+    }
+}
+
 impl ZipEntry {
+    pub(crate) fn new(filename: ZipString, compression: Compression) -> Self {
+        ZipEntry {
+            filename,
+            compression,
+            #[cfg(any(
+                feature = "deflate",
+                feature = "bzip2",
+                feature = "zstd",
+                feature = "lzma",
+                feature = "xz",
+                feature = "deflate64"
+            ))]
+            compression_level: async_compression::Level::Default,
+            crc32: 0,
+            uncompressed_size: 0,
+            compressed_size: 0,
+            attribute_compatibility: AttributeCompatibility::Unix,
+            last_modification_date: ZipDateTime::default(),
+            internal_file_attribute: 0,
+            external_file_attribute: 0,
+            extra_fields: Vec::new(),
+            comment: String::new().into(),
+            data_descriptor: false,
+            file_offset: 0,
+        }
+    }
+
     /// Returns the entry's filename.
     ///
     /// ## Note

--- a/src/file/builder.rs
+++ b/src/file/builder.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::{file::ZipFile, string::ZipString};
+
+/// A builder for [`ZipFile`].
+pub struct ZipFileBuilder(pub(crate) ZipFile);
+
+impl From<ZipFile> for ZipFileBuilder {
+    fn from(file: ZipFile) -> Self {
+        Self(file)
+    }
+}
+
+impl Default for ZipFileBuilder {
+    fn default() -> Self {
+        ZipFileBuilder(ZipFile { entries: Vec::new(), zip64: false, comment: String::new().into() })
+    }
+}
+
+impl ZipFileBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the file's comment.
+    pub fn comment(mut self, comment: ZipString) -> Self {
+        self.0.comment = comment;
+        self
+    }
+
+    /// Consumes this builder and returns a final [`ZipFile`].
+    ///
+    /// This is equivalent to:
+    /// ```
+    /// # use async_zip::{ZipFile, ZipFileBuilder};
+    /// #
+    /// # let builder = ZipFileBuilder::new();
+    /// let file: ZipFile = builder.into();
+    /// ```
+    pub fn build(self) -> ZipFile {
+        self.into()
+    }
+}

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
+pub(crate) mod builder;
+
 use crate::{entry::StoredZipEntry, string::ZipString};
+use builder::ZipFileBuilder;
 
 /// An immutable store of data about a ZIP file.
 #[derive(Clone)]
@@ -9,6 +12,12 @@ pub struct ZipFile {
     pub(crate) entries: Vec<StoredZipEntry>,
     pub(crate) zip64: bool,
     pub(crate) comment: ZipString,
+}
+
+impl From<ZipFileBuilder> for ZipFile {
+    fn from(builder: ZipFileBuilder) -> Self {
+        builder.0
+    }
 }
 
 impl ZipFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,8 @@ pub(crate) mod tests;
 pub use crate::spec::attribute::AttributeCompatibility;
 pub use crate::spec::compression::{Compression, DeflateOption};
 
-pub use crate::date::ZipDateTime;
-pub use crate::entry::{StoredZipEntry, ZipEntry};
-pub use crate::file::ZipFile;
+pub use crate::date::{builder::ZipDateTimeBuilder, ZipDateTime};
+pub use crate::entry::{builder::ZipEntryBuilder, StoredZipEntry, ZipEntry};
+pub use crate::file::{builder::ZipFileBuilder, ZipFile};
 
 pub use crate::string::{StringEncoding, ZipString};

--- a/src/spec/compression.rs
+++ b/src/spec/compression.rs
@@ -3,6 +3,9 @@
 
 use crate::error::{Result, ZipError};
 
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+use async_compression::Level;
+
 /// A compression method supported by this crate.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,4 +95,17 @@ pub enum DeflateOption {
 
     /// Other implementation defined level.
     Other(i32),
+}
+
+#[cfg(any(feature = "deflate", feature = "bzip2", feature = "zstd", feature = "lzma", feature = "xz"))]
+impl DeflateOption {
+    pub(crate) fn into_level(self) -> Level {
+        // FIXME: There's no clear documentation on what these specific levels defined in the ZIP specification relate
+        // to. We want to be compatible with any other library, and not specific to `async_compression`'s levels.
+        if let Self::Other(l) = self {
+            Level::Precise(l)
+        } else {
+            Level::Default
+        }
+    }
 }

--- a/src/spec/consts.rs
+++ b/src/spec/consts.rs
@@ -36,6 +36,8 @@ pub const ZIP64_EOCDL_LENGTH: u64 = 20;
 
 /// The contents of a header field when one must reference the zip64 version instead.
 pub const NON_ZIP64_MAX_SIZE: u32 = 0xFFFFFFFF;
+/// The maximum number of files or disks in a ZIP file before it requires ZIP64.
+pub const NON_ZIP64_MAX_NUM_FILES: u16 = 0xFFFF;
 
 // https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#439
 pub const DATA_DESCRIPTOR_SIGNATURE: u32 = 0x8074b50;

--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -8,6 +8,151 @@ use crate::spec::header::{
 
 use super::consts::NON_ZIP64_MAX_SIZE;
 
+pub(crate) trait ExtraFieldAsBytes {
+    fn as_bytes(&self) -> Vec<u8>;
+
+    fn count_bytes(&self) -> usize;
+}
+
+impl ExtraFieldAsBytes for &[ExtraField] {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        for field in self.iter() {
+            buffer.append(&mut field.as_bytes());
+        }
+        buffer
+    }
+
+    fn count_bytes(&self) -> usize {
+        self.iter().map(|field| field.count_bytes()).sum()
+    }
+}
+
+impl ExtraFieldAsBytes for ExtraField {
+    fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            ExtraField::Zip64ExtendedInformation(field) => field.as_bytes(),
+            ExtraField::InfoZipUnicodeComment(field) => field.as_bytes(),
+            ExtraField::InfoZipUnicodePath(field) => field.as_bytes(),
+            ExtraField::Unknown(field) => field.as_bytes(),
+        }
+    }
+
+    fn count_bytes(&self) -> usize {
+        match self {
+            ExtraField::Zip64ExtendedInformation(field) => field.count_bytes(),
+            ExtraField::InfoZipUnicodeComment(field) => field.count_bytes(),
+            ExtraField::InfoZipUnicodePath(field) => field.count_bytes(),
+            ExtraField::Unknown(field) => field.count_bytes(),
+        }
+    }
+}
+
+impl ExtraFieldAsBytes for UnknownExtraField {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let header_id: u16 = self.header_id.into();
+        bytes.append(&mut header_id.to_le_bytes().to_vec());
+        bytes.append(&mut self.data_size.to_le_bytes().to_vec());
+        bytes.append(&mut self.content.clone());
+
+        bytes
+    }
+
+    fn count_bytes(&self) -> usize {
+        4 + self.content.len()
+    }
+}
+
+impl ExtraFieldAsBytes for Zip64ExtendedInformationExtraField {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let header_id: u16 = HeaderId::ZIP64_EXTENDED_INFORMATION_EXTRA_FIELD.into();
+        bytes.append(&mut header_id.to_le_bytes().to_vec());
+        bytes.append(&mut (self.content_size() as u16).to_le_bytes().to_vec());
+        if let Some(uncompressed_size) = &self.uncompressed_size {
+            bytes.append(&mut uncompressed_size.to_le_bytes().to_vec());
+        }
+        if let Some(compressed_size) = &self.compressed_size {
+            bytes.append(&mut compressed_size.to_le_bytes().to_vec());
+        }
+        if let Some(relative_header_offset) = &self.relative_header_offset {
+            bytes.append(&mut relative_header_offset.to_le_bytes().to_vec());
+        }
+        if let Some(disk_start_number) = &self.disk_start_number {
+            bytes.append(&mut disk_start_number.to_le_bytes().to_vec());
+        }
+
+        bytes
+    }
+
+    fn count_bytes(&self) -> usize {
+        4 + self.content_size()
+    }
+}
+
+impl ExtraFieldAsBytes for InfoZipUnicodeCommentExtraField {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let header_id: u16 = HeaderId::INFO_ZIP_UNICODE_COMMENT_EXTRA_FIELD.into();
+        bytes.append(&mut header_id.to_le_bytes().to_vec());
+        match self {
+            InfoZipUnicodeCommentExtraField::V1 { crc32, unicode } => {
+                let data_size: u16 = (5 + unicode.len()).try_into().unwrap();
+                bytes.append(&mut data_size.to_le_bytes().to_vec());
+                bytes.push(1);
+                bytes.append(&mut crc32.to_le_bytes().to_vec());
+                bytes.append(&mut unicode.clone());
+            }
+            InfoZipUnicodeCommentExtraField::Unknown { version, data } => {
+                let data_size: u16 = (1 + data.len()).try_into().unwrap();
+                bytes.append(&mut data_size.to_le_bytes().to_vec());
+                bytes.push(*version);
+                bytes.append(&mut data.clone());
+            }
+        }
+        bytes
+    }
+
+    fn count_bytes(&self) -> usize {
+        match self {
+            InfoZipUnicodeCommentExtraField::V1 { unicode, .. } => 9 + unicode.len(),
+            InfoZipUnicodeCommentExtraField::Unknown { data, .. } => 5 + data.len(),
+        }
+    }
+}
+
+impl ExtraFieldAsBytes for InfoZipUnicodePathExtraField {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let header_id: u16 = HeaderId::INFO_ZIP_UNICODE_PATH_EXTRA_FIELD.into();
+        bytes.append(&mut header_id.to_le_bytes().to_vec());
+        match self {
+            InfoZipUnicodePathExtraField::V1 { crc32, unicode } => {
+                let data_size: u16 = (5 + unicode.len()).try_into().unwrap();
+                bytes.append(&mut data_size.to_le_bytes().to_vec());
+                bytes.push(1);
+                bytes.append(&mut crc32.to_le_bytes().to_vec());
+                bytes.append(&mut unicode.clone());
+            }
+            InfoZipUnicodePathExtraField::Unknown { version, data } => {
+                let data_size: u16 = (1 + data.len()).try_into().unwrap();
+                bytes.append(&mut data_size.to_le_bytes().to_vec());
+                bytes.push(*version);
+                bytes.append(&mut data.clone());
+            }
+        }
+        bytes
+    }
+
+    fn count_bytes(&self) -> usize {
+        match self {
+            InfoZipUnicodePathExtraField::V1 { unicode, .. } => 9 + unicode.len(),
+            InfoZipUnicodePathExtraField::Unknown { data, .. } => 5 + data.len(),
+        }
+    }
+}
+
 /// Parse a zip64 extra field from bytes.
 /// The content of "data" should exclude the header.
 fn zip64_extended_information_field_from_bytes(
@@ -157,5 +302,53 @@ pub(crate) fn extra_field_from_bytes(
             info_zip_unicode_path_extra_field_from_bytes(header_id, data_size, data)?,
         )),
         _ => Ok(ExtraField::Unknown(UnknownExtraField { header_id, data_size, content: data.to_vec() })),
+    }
+}
+
+pub struct Zip64ExtendedInformationExtraFieldBuilder {
+    field: Zip64ExtendedInformationExtraField,
+}
+
+impl Zip64ExtendedInformationExtraFieldBuilder {
+    pub fn new() -> Self {
+        Self {
+            field: Zip64ExtendedInformationExtraField {
+                uncompressed_size: None,
+                compressed_size: None,
+                relative_header_offset: None,
+                disk_start_number: None,
+            },
+        }
+    }
+
+    pub fn sizes(mut self, compressed_size: u64, uncompressed_size: u64) -> Self {
+        self.field.compressed_size = Some(compressed_size);
+        self.field.uncompressed_size = Some(uncompressed_size);
+        self
+    }
+
+    pub fn relative_header_offset(mut self, relative_header_offset: u64) -> Self {
+        self.field.relative_header_offset = Some(relative_header_offset);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn disk_start_number(mut self, disk_start_number: u32) -> Self {
+        self.field.disk_start_number = Some(disk_start_number);
+        self
+    }
+
+    pub fn eof_only(&self) -> bool {
+        (self.field.uncompressed_size.is_none() && self.field.compressed_size.is_none())
+            && (self.field.relative_header_offset.is_some() || self.field.disk_start_number.is_some())
+    }
+
+    pub fn build(self) -> ZipResult<Zip64ExtendedInformationExtraField> {
+        let field = self.field;
+
+        if field.content_size() == 0 {
+            return Err(ZipError::Zip64ExtendedFieldIncomplete);
+        }
+        Ok(field)
     }
 }

--- a/src/spec/extra_field.rs
+++ b/src/spec/extra_field.rs
@@ -153,6 +153,28 @@ impl ExtraFieldAsBytes for InfoZipUnicodePathExtraField {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zip64_disk_start_number_size_matches_serialized_bytes() {
+        let field = Zip64ExtendedInformationExtraField {
+            uncompressed_size: None,
+            compressed_size: None,
+            relative_header_offset: None,
+            disk_start_number: Some(0x0102_0304),
+        };
+
+        let bytes = field.as_bytes();
+
+        assert_eq!(field.count_bytes(), bytes.len());
+        assert_eq!(bytes.len(), 8);
+        assert_eq!(u16::from_le_bytes(bytes[2..4].try_into().unwrap()), 4);
+        assert_eq!(&bytes[4..], &0x0102_0304u32.to_le_bytes());
+    }
+}
+
 /// Parse a zip64 extra field from bytes.
 /// The content of "data" should exclude the header.
 fn zip64_extended_information_field_from_bytes(

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -86,7 +86,7 @@ impl Zip64ExtendedInformationExtraField {
         self.uncompressed_size.map(|_| 8).unwrap_or_default()
             + self.compressed_size.map(|_| 8).unwrap_or_default()
             + self.relative_header_offset.map(|_| 8).unwrap_or_default()
-            + self.disk_start_number.map(|_| 8).unwrap_or_default()
+            + self.disk_start_number.map(|_| 4).unwrap_or_default()
     }
 }
 

--- a/src/spec/header.rs
+++ b/src/spec/header.rs
@@ -81,6 +81,15 @@ pub struct Zip64ExtendedInformationExtraField {
     pub disk_start_number: Option<u32>,
 }
 
+impl Zip64ExtendedInformationExtraField {
+    pub(crate) fn content_size(&self) -> usize {
+        self.uncompressed_size.map(|_| 8).unwrap_or_default()
+            + self.compressed_size.map(|_| 8).unwrap_or_default()
+            + self.relative_header_offset.map(|_| 8).unwrap_or_default()
+            + self.disk_start_number.map(|_| 8).unwrap_or_default()
+    }
+}
+
 /// Stores the UTF-8 version of the file comment as stored in the central directory header.
 /// https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#468
 #[derive(Clone, Debug)]

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -8,5 +8,6 @@ pub(crate) mod data_descriptor;
 pub(crate) mod extra_field;
 pub(crate) mod header;
 pub(crate) mod parse;
+pub(crate) mod version;
 
 pub use compression::Compression;

--- a/src/spec/parse.rs
+++ b/src/spec/parse.rs
@@ -9,6 +9,88 @@ use crate::spec::header::{
 
 use futures_lite::io::{AsyncRead, AsyncReadExt};
 
+impl LocalFileHeader {
+    pub fn as_slice(&self) -> [u8; 26] {
+        let mut array = [0; 26];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.version.to_le_bytes());
+        array_push!(array, cursor, self.flags.as_slice());
+        array_push!(array, cursor, self.compression.to_le_bytes());
+        array_push!(array, cursor, self.mod_time.to_le_bytes());
+        array_push!(array, cursor, self.mod_date.to_le_bytes());
+        array_push!(array, cursor, self.crc.to_le_bytes());
+        array_push!(array, cursor, self.compressed_size.to_le_bytes());
+        array_push!(array, cursor, self.uncompressed_size.to_le_bytes());
+        array_push!(array, cursor, self.file_name_length.to_le_bytes());
+        array_push!(array, cursor, self.extra_field_length.to_le_bytes());
+
+        array
+    }
+}
+
+impl GeneralPurposeFlag {
+    pub fn as_slice(&self) -> [u8; 2] {
+        let encrypted: u16 = match self.encrypted {
+            false => 0x0,
+            true => 0b1,
+        };
+        let data_descriptor: u16 = match self.data_descriptor {
+            false => 0x0,
+            true => 0x8,
+        };
+        let filename_unicode: u16 = match self.filename_unicode {
+            false => 0x0,
+            true => 0x800,
+        };
+
+        (encrypted | data_descriptor | filename_unicode).to_le_bytes()
+    }
+}
+
+impl CentralDirectoryRecord {
+    pub fn as_slice(&self) -> [u8; 42] {
+        let mut array = [0; 42];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.v_made_by.to_le_bytes());
+        array_push!(array, cursor, self.v_needed.to_le_bytes());
+        array_push!(array, cursor, self.flags.as_slice());
+        array_push!(array, cursor, self.compression.to_le_bytes());
+        array_push!(array, cursor, self.mod_time.to_le_bytes());
+        array_push!(array, cursor, self.mod_date.to_le_bytes());
+        array_push!(array, cursor, self.crc.to_le_bytes());
+        array_push!(array, cursor, self.compressed_size.to_le_bytes());
+        array_push!(array, cursor, self.uncompressed_size.to_le_bytes());
+        array_push!(array, cursor, self.file_name_length.to_le_bytes());
+        array_push!(array, cursor, self.extra_field_length.to_le_bytes());
+        array_push!(array, cursor, self.file_comment_length.to_le_bytes());
+        array_push!(array, cursor, self.disk_start.to_le_bytes());
+        array_push!(array, cursor, self.inter_attr.to_le_bytes());
+        array_push!(array, cursor, self.exter_attr.to_le_bytes());
+        array_push!(array, cursor, self.lh_offset.to_le_bytes());
+
+        array
+    }
+}
+
+impl EndOfCentralDirectoryHeader {
+    pub fn as_slice(&self) -> [u8; 18] {
+        let mut array = [0; 18];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.disk_num.to_le_bytes());
+        array_push!(array, cursor, self.start_cent_dir_disk.to_le_bytes());
+        array_push!(array, cursor, self.num_of_entries_disk.to_le_bytes());
+        array_push!(array, cursor, self.num_of_entries.to_le_bytes());
+        array_push!(array, cursor, self.size_cent_dir.to_le_bytes());
+        array_push!(array, cursor, self.cent_dir_offset.to_le_bytes());
+        array_push!(array, cursor, self.file_comm_length.to_le_bytes());
+
+        array
+    }
+}
+
 impl From<[u8; 26]> for LocalFileHeader {
     fn from(value: [u8; 26]) -> LocalFileHeader {
         LocalFileHeader {
@@ -260,6 +342,17 @@ impl Zip64EndOfCentralDirectoryLocator {
         let mut buffer: [u8; 16] = [0; 16];
         reader.read_exact(&mut buffer).await?;
         Ok(Some(Self::from(buffer)))
+    }
+
+    pub fn as_bytes(&self) -> [u8; 16] {
+        let mut array = [0; 16];
+        let mut cursor = 0;
+
+        array_push!(array, cursor, self.number_of_disk_with_start_of_zip64_end_of_central_directory.to_le_bytes());
+        array_push!(array, cursor, self.relative_offset.to_le_bytes());
+        array_push!(array, cursor, self.total_number_of_disks.to_le_bytes());
+
+        array
     }
 }
 

--- a/src/spec/version.rs
+++ b/src/spec/version.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::entry::ZipEntry;
+#[cfg(any(
+    feature = "deflate",
+    feature = "bzip2",
+    feature = "zstd",
+    feature = "lzma",
+    feature = "xz",
+    feature = "deflate64"
+))]
+use crate::spec::Compression;
+
+pub(crate) const SPEC_VERSION_MADE_BY: u16 = 63;
+
+// https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#443
+pub fn as_needed_to_extract(entry: &ZipEntry) -> u16 {
+    let mut version = match entry.compression() {
+        #[cfg(feature = "deflate")]
+        Compression::Deflate => 20,
+        #[cfg(feature = "deflate64")]
+        Compression::Deflate64 => 21,
+        #[cfg(feature = "bzip2")]
+        Compression::Bz => 46,
+        #[cfg(feature = "lzma")]
+        Compression::Lzma => 63,
+        _ => 10,
+    };
+
+    if let Ok(true) = entry.dir() {
+        version = std::cmp::max(version, 20);
+    }
+
+    version
+}
+
+// https://github.com/Majored/rs-async-zip/blob/main/SPECIFICATION.md#442
+pub fn as_made_by() -> u16 {
+    // Default to UNIX mapping for the moment.
+    3 << 8 | SPEC_VERSION_MADE_BY
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,8 @@
 
 pub(crate) mod combined;
 pub(crate) mod read;
+pub(crate) mod spec;
+pub(crate) mod write;
 
 use std::sync::Once;
 static ENV_LOGGER: Once = Once::new();

--- a/src/tests/spec/date.rs
+++ b/src/tests/spec/date.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+#[cfg(feature = "chrono")]
+use chrono::{TimeZone, Utc};
+
+use crate::ZipDateTimeBuilder;
+
+#[test]
+#[cfg(feature = "chrono")]
+fn date_conversion_test_chrono() {
+    let original_dt = Utc.timestamp_opt(1666544102, 0).unwrap();
+    let zip_dt = crate::ZipDateTime::from_chrono(&original_dt);
+    let result_dt = zip_dt.as_chrono().single().expect("expected single unique result");
+    assert_eq!(result_dt, original_dt);
+}
+
+#[test]
+fn date_conversion_test() {
+    let year = 2000;
+    let month = 9;
+    let day = 8;
+    let hour = 7;
+    let minute = 5;
+    let second = 4;
+
+    let mut builder = ZipDateTimeBuilder::new();
+
+    builder = builder.year(year);
+    builder = builder.month(month);
+    builder = builder.day(day);
+    builder = builder.hour(hour);
+    builder = builder.minute(minute);
+    builder = builder.second(second);
+
+    let built = builder.build();
+
+    assert_eq!(year, built.year());
+    assert_eq!(month, built.month());
+    assert_eq!(day, built.day());
+    assert_eq!(hour, built.hour());
+    assert_eq!(minute, built.minute());
+    assert_eq!(second, built.second());
+}

--- a/src/tests/spec/mod.rs
+++ b/src/tests/spec/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+pub(crate) mod date;

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use futures_lite::io::AsyncWrite;
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub(crate) mod offset;
+mod zip64;
+
+/// /dev/null for AsyncWrite.
+/// Useful for tests that involve writing, but not reading, large amounts of data.
+pub(crate) struct AsyncSink;
+
+// AsyncSink is always ready to receive bytes and throw them away.
+impl AsyncWrite for AsyncSink {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -9,6 +9,8 @@ use std::task::{Context, Poll};
 use crate::base::write::{central_directory_size_field, ZipFileWriter};
 use crate::error::{Zip64ErrorCase, ZipError};
 use crate::spec::consts::NON_ZIP64_MAX_SIZE;
+#[cfg(feature = "deflate64")]
+use crate::{Compression, ZipEntryBuilder};
 
 pub(crate) mod offset;
 mod zip64;
@@ -41,6 +43,32 @@ async fn reject_large_archive_comment() {
     let result = writer.close().await;
 
     assert!(matches!(result, Err(ZipError::CommentTooLarge)));
+    assert!(buffer.is_empty());
+}
+
+#[cfg(feature = "deflate64")]
+#[tokio::test]
+async fn reject_deflate64_whole_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Deflate64);
+
+    let result = writer.write_entry_whole(entry, b"data").await;
+
+    assert!(matches!(result, Err(ZipError::FeatureNotSupported("Deflate64 writing"))));
+    assert!(buffer.is_empty());
+}
+
+#[cfg(feature = "deflate64")]
+#[tokio::test]
+async fn reject_deflate64_stream_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Deflate64);
+
+    let result = writer.write_entry_stream(entry).await;
+
+    assert!(matches!(result, Err(ZipError::FeatureNotSupported("Deflate64 writing"))));
     assert!(buffer.is_empty());
 }
 

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -6,6 +6,9 @@ use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::base::write::ZipFileWriter;
+use crate::error::ZipError;
+
 pub(crate) mod offset;
 mod zip64;
 
@@ -26,4 +29,16 @@ impl AsyncWrite for AsyncSink {
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
     }
+}
+
+#[tokio::test]
+async fn reject_large_archive_comment() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    writer.comment("x".repeat(u16::MAX as usize + 1));
+
+    let result = writer.close().await;
+
+    assert!(matches!(result, Err(ZipError::CommentTooLarge)));
+    assert!(buffer.is_empty());
 }

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -6,8 +6,9 @@ use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::base::write::ZipFileWriter;
-use crate::error::ZipError;
+use crate::base::write::{central_directory_size_field, ZipFileWriter};
+use crate::error::{Zip64ErrorCase, ZipError};
+use crate::spec::consts::NON_ZIP64_MAX_SIZE;
 
 pub(crate) mod offset;
 mod zip64;
@@ -41,4 +42,24 @@ async fn reject_large_archive_comment() {
 
     assert!(matches!(result, Err(ZipError::CommentTooLarge)));
     assert!(buffer.is_empty());
+}
+
+#[test]
+fn large_central_directory_size_uses_zip64() {
+    let mut is_zip64 = false;
+
+    let field = central_directory_size_field(NON_ZIP64_MAX_SIZE as u64 + 1, false, &mut is_zip64).unwrap();
+
+    assert_eq!(field, NON_ZIP64_MAX_SIZE);
+    assert!(is_zip64);
+}
+
+#[test]
+fn large_central_directory_size_errors_without_zip64() {
+    let mut is_zip64 = false;
+
+    let result = central_directory_size_field(NON_ZIP64_MAX_SIZE as u64 + 1, true, &mut is_zip64);
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile))));
+    assert!(!is_zip64);
 }

--- a/src/tests/write/offset/mod.rs
+++ b/src/tests/write/offset/mod.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::base::write::io::offset::AsyncOffsetWriter;
+
+#[tokio::test]
+async fn basic() {
+    use futures_lite::io::AsyncWriteExt;
+    use futures_lite::io::Cursor;
+
+    let mut writer = AsyncOffsetWriter::new(Cursor::new(Vec::new()));
+    assert_eq!(writer.offset(), 0);
+
+    writer.write_all(b"Foo. Bar. Foo. Bar.").await.expect("failed to write data");
+    assert_eq!(writer.offset(), 19);
+
+    writer.write_all(b"Foo. Foo.").await.expect("failed to write data");
+    assert_eq!(writer.offset(), 28);
+
+    writer.write_all(b"Bar. Bar.").await.expect("failed to write data");
+    assert_eq!(writer.offset(), 37);
+}

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -226,6 +226,7 @@ async fn test_force_no_zip64_errors_with_too_many_files_whole() {
     let result = writer.write_entry_whole(entry, &[]).await;
 
     assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+    assert_eq!(writer.cd_entries.len(), u16::MAX as usize);
 }
 
 /// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write more than
@@ -240,10 +241,10 @@ async fn test_force_no_zip64_errors_with_too_many_files_stream() {
         entrywriter.close().await.unwrap();
     }
     let entry = ZipEntryBuilder::new("65537".to_string().into(), Compression::Stored);
-    let entrywriter = writer.write_entry_stream(entry).await.unwrap();
-    let result = entrywriter.close().await;
+    let result = writer.write_entry_stream(entry).await;
 
     assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+    assert_eq!(writer.cd_entries.len(), u16::MAX as usize);
 }
 
 /// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::base::write::ZipFileWriter;
 use crate::error::{Zip64ErrorCase, ZipError};
-use crate::spec::consts::NON_ZIP64_MAX_SIZE;
+use crate::spec::consts::{CDH_SIGNATURE, DATA_DESCRIPTOR_SIGNATURE, NON_ZIP64_MAX_SIZE};
 use crate::tests::init_logger;
 use crate::tests::write::AsyncSink;
 use crate::{Compression, ZipEntryBuilder};
@@ -46,6 +46,29 @@ async fn test_write_zip64_file() {
     let mut buffer = Vec::new();
     file2.read_to_end(&mut buffer).unwrap();
     assert_eq!(buffer.as_slice(), &[0, 0, 0, 0]);
+}
+
+/// Test that streaming ZIP64 entries write ZIP64-width data descriptor sizes.
+#[tokio::test]
+async fn test_write_stream_zip64_data_descriptor_sizes() {
+    let data = b"data";
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    entry_writer.write_all(data).await.unwrap();
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    let signature = DATA_DESCRIPTOR_SIGNATURE.to_le_bytes();
+    let descriptor_offset = buffer.windows(signature.len()).position(|window| window == signature).unwrap();
+
+    let compressed_size = u64::from_le_bytes(buffer[descriptor_offset + 8..descriptor_offset + 16].try_into().unwrap());
+    let uncompressed_size =
+        u64::from_le_bytes(buffer[descriptor_offset + 16..descriptor_offset + 24].try_into().unwrap());
+    assert_eq!(compressed_size, data.len() as u64);
+    assert_eq!(uncompressed_size, data.len() as u64);
+    assert_eq!(&buffer[descriptor_offset + 24..descriptor_offset + 28], &CDH_SIGNATURE.to_le_bytes(),);
 }
 
 /// Test writing a large zip64 file. This test will use upwards of 4GB of memory.

--- a/src/tests/write/zip64/mod.rs
+++ b/src/tests/write/zip64/mod.rs
@@ -1,0 +1,243 @@
+// Copyright Cognite AS, 2023
+
+use crate::base::write::ZipFileWriter;
+use crate::error::{Zip64ErrorCase, ZipError};
+use crate::spec::consts::NON_ZIP64_MAX_SIZE;
+use crate::tests::init_logger;
+use crate::tests::write::AsyncSink;
+use crate::{Compression, ZipEntryBuilder};
+use std::io::Read;
+
+use crate::spec::header::ExtraField;
+use futures_lite::io::AsyncWriteExt;
+
+// Useful constants for writing a large file.
+const BATCH_SIZE: usize = 100_000;
+const NUM_BATCHES: usize = NON_ZIP64_MAX_SIZE as usize / BATCH_SIZE + 1;
+const BATCHED_FILE_SIZE: usize = NUM_BATCHES * BATCH_SIZE;
+
+/// Test writing a small zip64 file.
+/// No zip64 extra fields will be emitted for EntryWhole.
+/// Z64 end of directory record & locator should be emitted
+#[tokio::test]
+async fn test_write_zip64_file() {
+    init_logger();
+
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer).force_zip64();
+    let entry = ZipEntryBuilder::new("file1".to_string().into(), Compression::Stored);
+    writer.write_entry_whole(entry, &[0, 0, 0, 0]).await.unwrap();
+    let entry = ZipEntryBuilder::new("file2".to_string().into(), Compression::Stored);
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    entry_writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    let mut file1 = zip.by_name("file1").unwrap();
+    assert_eq!(file1.extra_data(), Some(&[] as &[u8]));
+    let mut buffer = Vec::new();
+    file1.read_to_end(&mut buffer).unwrap();
+    assert_eq!(buffer.as_slice(), &[0, 0, 0, 0]);
+    drop(file1);
+
+    let mut file2 = zip.by_name("file2").unwrap();
+    let mut buffer = Vec::new();
+    file2.read_to_end(&mut buffer).unwrap();
+    assert_eq!(buffer.as_slice(), &[0, 0, 0, 0]);
+}
+
+/// Test writing a large zip64 file. This test will use upwards of 4GB of memory.
+#[tokio::test]
+async fn test_write_large_zip64_file() {
+    init_logger();
+
+    // Allocate space with some extra for metadata records
+    let mut buffer = Vec::with_capacity(BATCHED_FILE_SIZE + 100_000);
+    let mut writer = ZipFileWriter::new(&mut buffer);
+
+    // Stream-written zip files are dubiously spec-conformant. We need to specify a valid file size
+    // in order for rs-zip (and unzip) to correctly read these files.
+    let entry = ZipEntryBuilder::new("file".to_string().into(), Compression::Stored)
+        .size(BATCHED_FILE_SIZE as u64, BATCHED_FILE_SIZE as u64);
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    for _ in 0..NUM_BATCHES {
+        entry_writer.write_all(&[0; BATCH_SIZE]).await.unwrap();
+    }
+    entry_writer.close().await.unwrap();
+
+    assert!(writer.is_zip64);
+    let cd_entry = writer.cd_entries.last().unwrap();
+    match &cd_entry.entry.extra_fields.last().unwrap() {
+        ExtraField::Zip64ExtendedInformation(zip64) => {
+            assert_eq!(zip64.compressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
+            assert_eq!(zip64.uncompressed_size.unwrap(), BATCHED_FILE_SIZE as u64);
+        }
+        e => panic!("Expected a Zip64 extended field, got {:?}", e),
+    }
+    assert_eq!(cd_entry.header.uncompressed_size, NON_ZIP64_MAX_SIZE);
+    assert_eq!(cd_entry.header.compressed_size, NON_ZIP64_MAX_SIZE);
+    writer.close().await.unwrap();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut archive = zip::read::ZipArchive::new(cursor).unwrap();
+    let mut file = archive.by_name("file").unwrap();
+    assert_eq!(file.compression(), zip::CompressionMethod::Stored);
+    assert_eq!(file.size(), BATCHED_FILE_SIZE as u64);
+    let mut buffer = [0; 100_000];
+    let mut bytes_total = 0;
+    loop {
+        let read_bytes = file.read(&mut buffer).unwrap();
+        if read_bytes == 0 {
+            break;
+        }
+        bytes_total += read_bytes;
+    }
+    assert_eq!(bytes_total, BATCHED_FILE_SIZE);
+}
+
+/// Test writing a file, and reading it with async-zip
+#[tokio::test]
+async fn test_write_large_zip64_file_self_read() {
+    use futures_lite::io::AsyncReadExt;
+
+    init_logger();
+
+    // Allocate space with some extra for metadata records
+    let mut buffer = Vec::with_capacity(BATCHED_FILE_SIZE + 100_000);
+    let mut writer = ZipFileWriter::new(&mut buffer);
+
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    for _ in 0..NUM_BATCHES {
+        entry_writer.write_all(&[0; BATCH_SIZE]).await.unwrap();
+    }
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    let reader = crate::base::read::mem::ZipFileReader::new(buffer).await.unwrap();
+    assert!(reader.file().zip64);
+    assert_eq!(reader.file().entries[0].entry.filename().as_str().unwrap(), "file");
+    assert_eq!(reader.file().entries[0].entry.compressed_size, BATCHED_FILE_SIZE as u64);
+    let mut entry = reader.reader_without_entry(0).await.unwrap();
+
+    let mut buffer = [0; 100_000];
+    let mut bytes_total = 0;
+    loop {
+        let read_bytes = entry.read(&mut buffer).await.unwrap();
+        if read_bytes == 0 {
+            break;
+        }
+        bytes_total += read_bytes;
+    }
+    assert_eq!(bytes_total, BATCHED_FILE_SIZE);
+}
+
+/// Test writing a zip64 file with more than u16::MAX files.
+#[tokio::test]
+async fn test_write_zip64_file_many_entries() {
+    init_logger();
+
+    // The generated file will likely be ~3MB in size.
+    let mut buffer = Vec::with_capacity(3_500_000);
+
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(i.to_string().into(), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap();
+    }
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    assert_eq!(zip.len(), u16::MAX as usize + 2);
+
+    for i in 0..=u16::MAX as u32 + 1 {
+        let mut file = zip.by_name(&i.to_string()).unwrap();
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+    }
+}
+
+/// Tests that EntryWholeWriter switches to Zip64 mode when writing too many files for a non-Zip64.
+#[tokio::test]
+async fn test_zip64_when_many_files_whole() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(format!("{i}").into(), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap()
+    }
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+}
+
+/// Tests that EntryStreamWriter switches to Zip64 mode when writing too many files for a non-Zip64.
+#[tokio::test]
+async fn test_zip64_when_many_files_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink);
+    for i in 0..=u16::MAX as u32 + 1 {
+        let entry = ZipEntryBuilder::new(format!("{i}").into(), Compression::Stored);
+        let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+        entrywriter.close().await.unwrap();
+    }
+
+    assert!(writer.is_zip64);
+    writer.close().await.unwrap();
+}
+
+/// Tests that when force_no_zip64 is true, EntryWholeWriter errors when trying to write more than
+/// u16::MAX files to a single archive.
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_many_files_whole() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+    for i in 0..u16::MAX {
+        let entry = ZipEntryBuilder::new(format!("{i}").into(), Compression::Stored);
+        writer.write_entry_whole(entry, &[]).await.unwrap()
+    }
+    let entry = ZipEntryBuilder::new("65537".to_string().into(), Compression::Stored);
+    let result = writer.write_entry_whole(entry, &[]).await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+}
+
+/// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write more than
+/// u16::MAX files to a single archive.
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_many_files_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+    for i in 0..u16::MAX {
+        let entry = ZipEntryBuilder::new(format!("{i}").into(), Compression::Stored);
+        let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+        entrywriter.close().await.unwrap();
+    }
+    let entry = ZipEntryBuilder::new("65537".to_string().into(), Compression::Stored);
+    let entrywriter = writer.write_entry_stream(entry).await.unwrap();
+    let result = entrywriter.close().await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles))));
+}
+
+/// Tests that when force_no_zip64 is true, EntryStreamWriter errors when trying to write
+/// a file larger than ~4 GiB to an archive.
+#[tokio::test]
+async fn test_force_no_zip64_errors_with_too_large_file_stream() {
+    let mut sink = AsyncSink;
+    let mut writer = ZipFileWriter::new(&mut sink).force_no_zip64();
+
+    let entry = ZipEntryBuilder::new("-".to_string().into(), Compression::Stored);
+    let mut entrywriter = writer.write_entry_stream(entry).await.unwrap();
+
+    // Writing 4GB, 1kb at a time
+    for _ in 0..NUM_BATCHES {
+        entrywriter.write_all(&[0; BATCH_SIZE]).await.unwrap();
+    }
+    let result = entrywriter.close().await;
+
+    assert!(matches!(result, Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile))));
+}

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -25,3 +25,17 @@ use tokio;
 use tokio_util;
 
 pub mod read;
+
+pub mod write {
+    //! A module which supports writing ZIP files.
+
+    #[cfg(doc)]
+    use crate::base;
+    use tokio_util::compat::Compat;
+
+    /// A [`tokio`]-specific type alias for [`base::write::ZipFileWriter`];
+    pub type ZipFileWriter<W> = crate::base::write::ZipFileWriter<Compat<W>>;
+
+    /// A [`tokio`]-specific type alias for [`base::write::EntryStreamWriter`];
+    pub type EntryStreamWriter<'a, W> = crate::base::write::EntryStreamWriter<'a, Compat<W>>;
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,11 +3,38 @@
 
 use async_zip::base::read::mem;
 use async_zip::base::read::seek;
+use async_zip::base::write::ZipFileWriter;
+use async_zip::Compression;
+use async_zip::ZipEntryBuilder;
+use futures_lite::io::AsyncWriteExt;
 use tokio::fs::File;
 use tokio::io::BufReader;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 const FOLDER_PREFIX: &str = "tests/test_inputs";
+
+const FILE_LIST: &[&str] = &[
+    "sample_data/alpha/back_to_front.txt",
+    "sample_data/alpha/front_to_back.txt",
+    "sample_data/numeric/forward.txt",
+    "sample_data/numeric/reverse.txt",
+];
+
+pub async fn compress_to_mem(compress: Compression) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(10_000);
+    let mut writer = ZipFileWriter::new(&mut bytes);
+
+    for fname in FILE_LIST {
+        let content = tokio::fs::read(format!("{FOLDER_PREFIX}/{fname}")).await.unwrap();
+        let opts = ZipEntryBuilder::new(fname.to_string().into(), compress);
+
+        let mut entry_writer = writer.write_entry_stream(opts).await.unwrap();
+        entry_writer.write_all(&content).await.unwrap();
+        entry_writer.close().await.unwrap();
+    }
+    writer.close().await.unwrap();
+    bytes
+}
 
 #[cfg(feature = "tokio-fs")]
 pub async fn check_decompress_fs(fname: &str) {

--- a/tests/compress_test.rs
+++ b/tests/compress_test.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 Harry [Majored] [hello@majored.pw]
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use async_zip::{Compression, ZipEntryBuilder, ZipString};
+use futures_lite::AsyncWriteExt;
+
+mod common;
+
+#[cfg(feature = "zstd")]
+#[tokio::test]
+async fn zip_zstd_in_out() {
+    let zip_data = common::compress_to_mem(Compression::Zstd).await;
+    common::check_decompress_mem(zip_data).await
+}
+
+#[cfg(feature = "deflate")]
+#[tokio::test]
+async fn zip_decompress_in_out() {
+    let zip_data = common::compress_to_mem(Compression::Deflate).await;
+    common::check_decompress_mem(zip_data).await
+}
+
+#[tokio::test]
+async fn zip_store_in_out() {
+    let zip_data = common::compress_to_mem(Compression::Stored).await;
+    common::check_decompress_mem(zip_data).await
+}
+
+#[tokio::test]
+async fn zip_utf8_extra_in_out_stream() {
+    let mut zip_bytes = Vec::with_capacity(10_000);
+
+    {
+        // writing
+        let content = "Test".as_bytes();
+        let mut writer = async_zip::base::write::ZipFileWriter::new(&mut zip_bytes);
+        let filename =
+            ZipString::new_with_alternative("\u{4E2D}\u{6587}.txt".to_string(), b"\xD6\xD0\xCe\xC4.txt".to_vec());
+        let opts = ZipEntryBuilder::new(filename, Compression::Stored);
+
+        let mut entry_writer = writer.write_entry_stream(opts).await.unwrap();
+        entry_writer.write_all(content).await.unwrap();
+        entry_writer.close().await.unwrap();
+
+        writer.close().await.unwrap();
+    }
+
+    {
+        // reading
+        let zip = async_zip::base::read::mem::ZipFileReader::new(zip_bytes).await.unwrap();
+        let zip_entries: Vec<_> = zip.file().entries().to_vec();
+        assert_eq!(zip_entries.len(), 1);
+        assert_eq!(zip_entries[0].filename().as_str().unwrap(), "\u{4E2D}\u{6587}.txt");
+        assert_eq!(zip_entries[0].filename().alternative(), Some(b"\xD6\xD0\xCe\xC4.txt".as_ref()));
+    }
+}
+
+#[tokio::test]
+async fn zip_utf8_extra_in_out_whole() {
+    let mut zip_bytes = Vec::with_capacity(10_000);
+
+    {
+        // writing
+        let content = "Test".as_bytes();
+        let mut writer = async_zip::base::write::ZipFileWriter::new(&mut zip_bytes);
+        let filename =
+            ZipString::new_with_alternative("\u{4E2D}\u{6587}.txt".to_string(), b"\xD6\xD0\xCe\xC4.txt".to_vec());
+        let opts = ZipEntryBuilder::new(filename, Compression::Stored);
+        writer.write_entry_whole(opts, content).await.unwrap();
+        writer.close().await.unwrap();
+    }
+
+    {
+        // reading
+        let zip = async_zip::base::read::mem::ZipFileReader::new(zip_bytes).await.unwrap();
+        let zip_entries: Vec<_> = zip.file().entries().to_vec();
+        assert_eq!(zip_entries.len(), 1);
+        assert_eq!(zip_entries[0].filename().as_str().unwrap(), "\u{4E2D}\u{6587}.txt");
+        assert_eq!(zip_entries[0].filename().alternative(), Some(b"\xD6\xD0\xCe\xC4.txt".as_ref()));
+    }
+}

--- a/tests/decompress_test.rs
+++ b/tests/decompress_test.rs
@@ -6,9 +6,7 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 
 mod common;
 
-#[cfg(feature = "zstd")]
 const ZSTD_ZIP_FILE: &str = "tests/test_inputs/sample_data.zstd.zip";
-#[cfg(feature = "deflate")]
 const DEFLATE_ZIP_FILE: &str = "tests/test_inputs/sample_data.deflate.zip";
 const STORE_ZIP_FILE: &str = "tests/test_inputs/sample_data.store.zip";
 const UTF8_EXTRA_ZIP_FILE: &str = "tests/test_inputs/sample_data_utf8_extra.zip";
@@ -23,6 +21,13 @@ async fn decompress_zstd_zip_seek() {
 #[tokio::test]
 async fn decompress_deflate_zip_seek() {
     common::check_decompress_seek(DEFLATE_ZIP_FILE).await
+}
+
+#[tokio::test]
+async fn check_empty_zip_seek() {
+    let mut data: Vec<u8> = Vec::new();
+    async_zip::base::write::ZipFileWriter::new(futures::io::Cursor::new(&mut data)).close().await.unwrap();
+    async_zip::base::read::seek::ZipFileReader::new(futures::io::Cursor::new(&data)).await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

We want to use the async zip crate exclusively in uv, which necessitates re-adding writer support (removed in https://github.com/astral-sh/rs-async-zip/pull/15 for no reason other than that it was unused). This PR re-adds that support (first commit), then fixes four minor issues surfaced by GPT 5.5 in security review.
