### PR TITLE
Use `jiff` for ZIP timestamps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ categories = ["asynchronous", "compression"]
 name = "async_zip"
 
 [features]
-full = ["jiff-02", "tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
+full = ["jiff", "tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
 
 # All features that are compatible with WASM
-full-wasm = ["jiff-02", "deflate", "zstd"]
+full-wasm = ["jiff", "deflate", "zstd"]
 
 tokio = ["dep:tokio", "tokio-util", "tokio/io-util"]
 tokio-fs = ["tokio/fs"]
@@ -30,7 +30,7 @@ lzma = ["async-compression/lzma"]
 zstd = ["async-compression/zstd"]
 xz = ["async-compression/xz"]
 deflate64 = ["async-compression/deflate64"]
-jiff-02 = ["dep:jiff"]
+jiff = ["dep:jiff"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ categories = ["asynchronous", "compression"]
 name = "async_zip"
 
 [features]
-full = ["chrono", "tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
+full = ["jiff-02", "tokio-fs", "deflate", "bzip2", "lzma", "zstd", "xz", "deflate64"]
 
 # All features that are compatible with WASM
-full-wasm = ["chrono", "deflate", "zstd"]
+full-wasm = ["jiff-02", "deflate", "zstd"]
 
 tokio = ["dep:tokio", "tokio-util", "tokio/io-util"]
 tokio-fs = ["tokio/fs"]
@@ -30,6 +30,7 @@ lzma = ["async-compression/lzma"]
 zstd = ["async-compression/zstd"]
 xz = ["async-compression/xz"]
 deflate64 = ["async-compression/deflate64"]
+jiff-02 = ["dep:jiff"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -47,7 +48,7 @@ thiserror = "2.0.18"
 async-compression = { version = "0.4.2", default-features = false, features = [
     "futures-io",
 ], optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+jiff = { version = "0.2", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1", default-features = false, optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 
@@ -56,7 +57,7 @@ tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 env_logger = "0.11.2"
-zip = "2.1.5"
+zip = { version = "2.1.5", default-features = false }
 
 # shared across multiple examples
 anyhow = "1"

--- a/src/date/mod.rs
+++ b/src/date/mod.rs
@@ -3,8 +3,8 @@
 
 pub mod builder;
 
-#[cfg(feature = "chrono")]
-use chrono::{DateTime, Datelike, LocalResult, TimeZone, Timelike, Utc};
+#[cfg(feature = "jiff-02")]
+use jiff::{civil, tz::Offset, Timestamp};
 
 use self::builder::ZipDateTimeBuilder;
 
@@ -25,6 +25,19 @@ impl Default for ZipDateTime {
 }
 
 impl ZipDateTime {
+    /// Returns the current time if the `jiff-02` feature is enabled, otherwise the default of 1980-01-01.
+    pub fn default_for_write() -> Self {
+        #[cfg(feature = "jiff-02")]
+        {
+            Self::from_jiff(&Offset::UTC.to_datetime(Timestamp::now()))
+        }
+
+        #[cfg(not(feature = "jiff-02"))]
+        {
+            Self::default()
+        }
+    }
+
     /// Returns the year of this date & time.
     pub fn year(&self) -> i32 {
         (((self.date & 0xFE00) >> 9) + 1980).into()
@@ -57,20 +70,20 @@ impl ZipDateTime {
         ((self.time & 0x1F) << 1).into()
     }
 
-    /// Constructs chrono's [`DateTime`] representation of this date & time.
+    /// Constructs Jiff's [`civil::DateTime`] representation of this date & time.
     ///
-    /// Note that this requires the `chrono` feature.
-    #[cfg(feature = "chrono")]
-    pub fn as_chrono(&self) -> LocalResult<DateTime<Utc>> {
-        self.into()
+    /// Note that this requires the `jiff-02` feature.
+    #[cfg(feature = "jiff-02")]
+    pub fn as_jiff(&self) -> Result<civil::DateTime, jiff::Error> {
+        self.try_into()
     }
 
-    /// Constructs this date & time from chrono's [`DateTime`] representation.
+    /// Constructs this date & time from Jiff's [`civil::DateTime`] representation.
     ///
-    /// Note that this requires the `chrono` feature.
-    #[cfg(feature = "chrono")]
-    pub fn from_chrono(dt: &DateTime<Utc>) -> Self {
-        dt.into()
+    /// Note that this requires the `jiff-02` feature.
+    #[cfg(feature = "jiff-02")]
+    pub fn from_jiff(date_time: &civil::DateTime) -> Self {
+        date_time.into()
     }
 }
 
@@ -80,39 +93,51 @@ impl From<ZipDateTimeBuilder> for ZipDateTime {
     }
 }
 
-#[cfg(feature = "chrono")]
-impl From<&DateTime<Utc>> for ZipDateTime {
-    fn from(value: &DateTime<Utc>) -> Self {
+#[cfg(feature = "jiff-02")]
+impl From<&civil::DateTime> for ZipDateTime {
+    fn from(value: &civil::DateTime) -> Self {
         let mut builder = ZipDateTimeBuilder::new();
 
-        builder = builder.year(value.date_naive().year());
-        builder = builder.month(value.date_naive().month());
-        builder = builder.day(value.date_naive().day());
-        builder = builder.hour(value.time().hour());
-        builder = builder.minute(value.time().minute());
-        builder = builder.second(value.time().second());
+        builder = builder.year(value.year().into());
+        builder = builder.month(value.month() as u32);
+        builder = builder.day(value.day() as u32);
+        builder = builder.hour(value.hour() as u32);
+        builder = builder.minute(value.minute() as u32);
+        builder = builder.second(value.second() as u32);
 
         builder.build()
     }
 }
 
-#[cfg(feature = "chrono")]
-impl From<&ZipDateTime> for LocalResult<DateTime<Utc>> {
-    fn from(value: &ZipDateTime) -> Self {
-        Utc.with_ymd_and_hms(value.year(), value.month(), value.day(), value.hour(), value.minute(), value.second())
+#[cfg(feature = "jiff-02")]
+impl TryFrom<&ZipDateTime> for civil::DateTime {
+    type Error = jiff::Error;
+
+    fn try_from(value: &ZipDateTime) -> Result<Self, Self::Error> {
+        Self::new(
+            value.year() as i16,
+            value.month() as i8,
+            value.day() as i8,
+            value.hour() as i8,
+            value.minute() as i8,
+            value.second() as i8,
+            0,
+        )
     }
 }
 
-#[cfg(feature = "chrono")]
-impl From<DateTime<Utc>> for ZipDateTime {
-    fn from(value: DateTime<Utc>) -> Self {
+#[cfg(feature = "jiff-02")]
+impl From<civil::DateTime> for ZipDateTime {
+    fn from(value: civil::DateTime) -> Self {
         (&value).into()
     }
 }
 
-#[cfg(feature = "chrono")]
-impl From<ZipDateTime> for LocalResult<DateTime<Utc>> {
-    fn from(value: ZipDateTime) -> Self {
-        (&value).into()
+#[cfg(feature = "jiff-02")]
+impl TryFrom<ZipDateTime> for civil::DateTime {
+    type Error = jiff::Error;
+
+    fn try_from(value: ZipDateTime) -> Result<Self, Self::Error> {
+        (&value).try_into()
     }
 }

--- a/src/date/mod.rs
+++ b/src/date/mod.rs
@@ -12,10 +12,16 @@ use self::builder::ZipDateTimeBuilder;
 // https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-dosdatetimetovarianttime
 
 /// A date and time stored as per the MS-DOS representation used by ZIP files.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ZipDateTime {
     pub(crate) date: u16,
     pub(crate) time: u16,
+}
+
+impl Default for ZipDateTime {
+    fn default() -> Self {
+        ZipDateTimeBuilder::new().year(1980).month(1).day(1).build()
+    }
 }
 
 impl ZipDateTime {

--- a/src/date/mod.rs
+++ b/src/date/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod builder;
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 use jiff::{civil, tz::Offset, Timestamp};
 
 use self::builder::ZipDateTimeBuilder;
@@ -25,14 +25,14 @@ impl Default for ZipDateTime {
 }
 
 impl ZipDateTime {
-    /// Returns the current time if the `jiff-02` feature is enabled, otherwise the default of 1980-01-01.
+    /// Returns the current time if the `jiff` feature is enabled, otherwise the default of 1980-01-01.
     pub fn default_for_write() -> Self {
-        #[cfg(feature = "jiff-02")]
+        #[cfg(feature = "jiff")]
         {
             Self::from_jiff(&Offset::UTC.to_datetime(Timestamp::now()))
         }
 
-        #[cfg(not(feature = "jiff-02"))]
+        #[cfg(not(feature = "jiff"))]
         {
             Self::default()
         }
@@ -72,16 +72,16 @@ impl ZipDateTime {
 
     /// Constructs Jiff's [`civil::DateTime`] representation of this date & time.
     ///
-    /// Note that this requires the `jiff-02` feature.
-    #[cfg(feature = "jiff-02")]
+    /// Note that this requires the `jiff` feature.
+    #[cfg(feature = "jiff")]
     pub fn as_jiff(&self) -> Result<civil::DateTime, jiff::Error> {
         self.try_into()
     }
 
     /// Constructs this date & time from Jiff's [`civil::DateTime`] representation.
     ///
-    /// Note that this requires the `jiff-02` feature.
-    #[cfg(feature = "jiff-02")]
+    /// Note that this requires the `jiff` feature.
+    #[cfg(feature = "jiff")]
     pub fn from_jiff(date_time: &civil::DateTime) -> Self {
         date_time.into()
     }
@@ -93,7 +93,7 @@ impl From<ZipDateTimeBuilder> for ZipDateTime {
     }
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 impl From<&civil::DateTime> for ZipDateTime {
     fn from(value: &civil::DateTime) -> Self {
         let mut builder = ZipDateTimeBuilder::new();
@@ -109,7 +109,7 @@ impl From<&civil::DateTime> for ZipDateTime {
     }
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 impl TryFrom<&ZipDateTime> for civil::DateTime {
     type Error = jiff::Error;
 
@@ -126,14 +126,14 @@ impl TryFrom<&ZipDateTime> for civil::DateTime {
     }
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 impl From<civil::DateTime> for ZipDateTime {
     fn from(value: civil::DateTime) -> Self {
         (&value).into()
     }
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 impl TryFrom<ZipDateTime> for civil::DateTime {
     type Error = jiff::Error;
 

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -72,7 +72,7 @@ impl ZipEntry {
             uncompressed_size: 0,
             compressed_size: 0,
             attribute_compatibility: AttributeCompatibility::Unix,
-            last_modification_date: ZipDateTime::default(),
+            last_modification_date: ZipDateTime::default_for_write(),
             internal_file_attribute: 0,
             external_file_attribute: 0,
             extra_fields: Vec::new(),

--- a/src/tests/spec/date.rs
+++ b/src/tests/spec/date.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 use jiff::{civil, tz::Offset, Timestamp};
 
 use crate::{ZipDateTime, ZipDateTimeBuilder};
@@ -19,13 +19,13 @@ fn default_date_is_valid_msdos_epoch() {
 }
 
 #[test]
-#[cfg(not(feature = "jiff-02"))]
+#[cfg(not(feature = "jiff"))]
 fn default_for_write_uses_msdos_epoch_without_jiff() {
     assert_eq!(ZipDateTime::default(), ZipDateTime::default_for_write());
 }
 
 #[test]
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 fn default_for_write_uses_current_time_with_jiff() {
     let default = ZipDateTime::default_for_write();
     let now = Offset::UTC.to_datetime(Timestamp::now());
@@ -35,7 +35,7 @@ fn default_for_write_uses_current_time_with_jiff() {
 }
 
 #[test]
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 fn date_conversion_test_jiff() {
     let original_date_time = civil::datetime(2022, 10, 23, 18, 15, 2, 0);
     let zip_date_time = ZipDateTime::from_jiff(&original_date_time);

--- a/src/tests/spec/date.rs
+++ b/src/tests/spec/date.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-#[cfg(feature = "chrono")]
-use chrono::{TimeZone, Utc};
+#[cfg(feature = "jiff-02")]
+use jiff::{civil, tz::Offset, Timestamp};
 
-use crate::ZipDateTimeBuilder;
+use crate::{ZipDateTime, ZipDateTimeBuilder};
 
 #[test]
 fn default_date_is_valid_msdos_epoch() {
@@ -19,12 +19,29 @@ fn default_date_is_valid_msdos_epoch() {
 }
 
 #[test]
-#[cfg(feature = "chrono")]
-fn date_conversion_test_chrono() {
-    let original_dt = Utc.timestamp_opt(1666544102, 0).unwrap();
-    let zip_dt = crate::ZipDateTime::from_chrono(&original_dt);
-    let result_dt = zip_dt.as_chrono().single().expect("expected single unique result");
-    assert_eq!(result_dt, original_dt);
+#[cfg(not(feature = "jiff-02"))]
+fn default_for_write_uses_msdos_epoch_without_jiff() {
+    assert_eq!(ZipDateTime::default(), ZipDateTime::default_for_write());
+}
+
+#[test]
+#[cfg(feature = "jiff-02")]
+fn default_for_write_uses_current_time_with_jiff() {
+    let default = ZipDateTime::default_for_write();
+    let now = Offset::UTC.to_datetime(Timestamp::now());
+
+    assert_eq!(i32::from(now.year()), default.year());
+    assert_ne!(ZipDateTime::default(), default);
+}
+
+#[test]
+#[cfg(feature = "jiff-02")]
+fn date_conversion_test_jiff() {
+    let original_date_time = civil::datetime(2022, 10, 23, 18, 15, 2, 0);
+    let zip_date_time = ZipDateTime::from_jiff(&original_date_time);
+    let result_date_time = zip_date_time.as_jiff().expect("expected valid Jiff civil datetime");
+
+    assert_eq!(result_date_time, original_date_time);
 }
 
 #[test]

--- a/src/tests/spec/date.rs
+++ b/src/tests/spec/date.rs
@@ -7,6 +7,18 @@ use chrono::{TimeZone, Utc};
 use crate::ZipDateTimeBuilder;
 
 #[test]
+fn default_date_is_valid_msdos_epoch() {
+    let default = crate::ZipDateTime::default();
+
+    assert_eq!(1980, default.year());
+    assert_eq!(1, default.month());
+    assert_eq!(1, default.day());
+    assert_eq!(0, default.hour());
+    assert_eq!(0, default.minute());
+    assert_eq!(0, default.second());
+}
+
+#[test]
 #[cfg(feature = "chrono")]
 fn date_conversion_test_chrono() {
     let original_dt = Utc.timestamp_opt(1666544102, 0).unwrap();

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -2,7 +2,7 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use futures_lite::io::{AsyncWrite, AsyncWriteExt};
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 use jiff::{tz::Offset, Timestamp};
 use std::io::Error;
 use std::pin::Pin;
@@ -11,7 +11,7 @@ use std::task::{Context, Poll};
 use crate::base::write::{central_directory_size_field, ZipFileWriter};
 use crate::error::{Zip64ErrorCase, ZipError};
 use crate::spec::consts::{CDH_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE};
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 use crate::ZipDateTime;
 use crate::{Compression, ZipEntryBuilder};
 
@@ -37,7 +37,7 @@ impl AsyncWrite for AsyncSink {
     }
 }
 
-#[cfg(not(feature = "jiff-02"))]
+#[cfg(not(feature = "jiff"))]
 fn assert_default_modification_date(buffer: &[u8]) {
     let ((local_time, local_date), (central_time, central_date)) = modification_dates(buffer);
 
@@ -66,7 +66,7 @@ fn modification_dates(buffer: &[u8]) -> ((u16, u16), (u16, u16)) {
     ((local_time, local_date), (central_time, central_date))
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 fn assert_current_modification_date(buffer: &[u8]) {
     let ((local_time, local_date), (central_time, central_date)) = modification_dates(buffer);
     assert_eq!((local_time, local_date), (central_time, central_date));
@@ -78,7 +78,7 @@ fn assert_current_modification_date(buffer: &[u8]) {
     assert_ne!(ZipDateTime::default(), date);
 }
 
-#[cfg(not(feature = "jiff-02"))]
+#[cfg(not(feature = "jiff"))]
 #[tokio::test]
 async fn default_modification_date_is_valid_for_whole_writes() {
     let mut buffer = Vec::new();
@@ -91,7 +91,7 @@ async fn default_modification_date_is_valid_for_whole_writes() {
     assert_default_modification_date(&buffer);
 }
 
-#[cfg(not(feature = "jiff-02"))]
+#[cfg(not(feature = "jiff"))]
 #[tokio::test]
 async fn default_modification_date_is_valid_for_stream_writes() {
     let mut buffer = Vec::new();
@@ -106,7 +106,7 @@ async fn default_modification_date_is_valid_for_stream_writes() {
     assert_default_modification_date(&buffer);
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 #[tokio::test]
 async fn default_modification_date_uses_current_time_for_whole_writes() {
     let mut buffer = Vec::new();
@@ -119,7 +119,7 @@ async fn default_modification_date_uses_current_time_for_whole_writes() {
     assert_current_modification_date(&buffer);
 }
 
-#[cfg(feature = "jiff-02")]
+#[cfg(feature = "jiff")]
 #[tokio::test]
 async fn default_modification_date_uses_current_time_for_stream_writes() {
     let mut buffer = Vec::new();

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,15 +1,14 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use futures_lite::io::AsyncWrite;
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
 use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::base::write::{central_directory_size_field, ZipFileWriter};
 use crate::error::{Zip64ErrorCase, ZipError};
-use crate::spec::consts::NON_ZIP64_MAX_SIZE;
-#[cfg(feature = "deflate64")]
+use crate::spec::consts::{CDH_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE};
 use crate::{Compression, ZipEntryBuilder};
 
 pub(crate) mod offset;
@@ -32,6 +31,53 @@ impl AsyncWrite for AsyncSink {
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
     }
+}
+
+fn assert_default_modification_date(buffer: &[u8]) {
+    let local_header_signature = LFH_SIGNATURE.to_le_bytes();
+    assert_eq!(&buffer[..local_header_signature.len()], local_header_signature);
+    assert_eq!(u16::from_le_bytes(buffer[10..12].try_into().unwrap()), 0);
+    assert_eq!(u16::from_le_bytes(buffer[12..14].try_into().unwrap()), 0x21);
+
+    let central_directory_signature = CDH_SIGNATURE.to_le_bytes();
+    let central_directory_offset = buffer
+        .windows(central_directory_signature.len())
+        .position(|window| window == central_directory_signature)
+        .unwrap();
+    assert_eq!(
+        u16::from_le_bytes(buffer[central_directory_offset + 12..central_directory_offset + 14].try_into().unwrap()),
+        0
+    );
+    assert_eq!(
+        u16::from_le_bytes(buffer[central_directory_offset + 14..central_directory_offset + 16].try_into().unwrap()),
+        0x21
+    );
+}
+
+#[tokio::test]
+async fn default_modification_date_is_valid_for_whole_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    writer.write_entry_whole(entry, b"data").await.unwrap();
+    writer.close().await.unwrap();
+
+    assert_default_modification_date(&buffer);
+}
+
+#[tokio::test]
+async fn default_modification_date_is_valid_for_stream_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    assert_default_modification_date(&buffer);
 }
 
 #[tokio::test]

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -2,6 +2,8 @@
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
 use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+#[cfg(feature = "jiff-02")]
+use jiff::{tz::Offset, Timestamp};
 use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -9,6 +11,8 @@ use std::task::{Context, Poll};
 use crate::base::write::{central_directory_size_field, ZipFileWriter};
 use crate::error::{Zip64ErrorCase, ZipError};
 use crate::spec::consts::{CDH_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE};
+#[cfg(feature = "jiff-02")]
+use crate::ZipDateTime;
 use crate::{Compression, ZipEntryBuilder};
 
 pub(crate) mod offset;
@@ -33,27 +37,48 @@ impl AsyncWrite for AsyncSink {
     }
 }
 
+#[cfg(not(feature = "jiff-02"))]
 fn assert_default_modification_date(buffer: &[u8]) {
+    let ((local_time, local_date), (central_time, central_date)) = modification_dates(buffer);
+
+    assert_eq!(local_time, 0);
+    assert_eq!(local_date, 0x21);
+    assert_eq!(central_time, 0);
+    assert_eq!(central_date, 0x21);
+}
+
+fn modification_dates(buffer: &[u8]) -> ((u16, u16), (u16, u16)) {
     let local_header_signature = LFH_SIGNATURE.to_le_bytes();
     assert_eq!(&buffer[..local_header_signature.len()], local_header_signature);
-    assert_eq!(u16::from_le_bytes(buffer[10..12].try_into().unwrap()), 0);
-    assert_eq!(u16::from_le_bytes(buffer[12..14].try_into().unwrap()), 0x21);
+    let local_time = u16::from_le_bytes(buffer[10..12].try_into().unwrap());
+    let local_date = u16::from_le_bytes(buffer[12..14].try_into().unwrap());
 
     let central_directory_signature = CDH_SIGNATURE.to_le_bytes();
     let central_directory_offset = buffer
         .windows(central_directory_signature.len())
         .position(|window| window == central_directory_signature)
         .unwrap();
-    assert_eq!(
-        u16::from_le_bytes(buffer[central_directory_offset + 12..central_directory_offset + 14].try_into().unwrap()),
-        0
-    );
-    assert_eq!(
-        u16::from_le_bytes(buffer[central_directory_offset + 14..central_directory_offset + 16].try_into().unwrap()),
-        0x21
-    );
+    let central_time =
+        u16::from_le_bytes(buffer[central_directory_offset + 12..central_directory_offset + 14].try_into().unwrap());
+    let central_date =
+        u16::from_le_bytes(buffer[central_directory_offset + 14..central_directory_offset + 16].try_into().unwrap());
+
+    ((local_time, local_date), (central_time, central_date))
 }
 
+#[cfg(feature = "jiff-02")]
+fn assert_current_modification_date(buffer: &[u8]) {
+    let ((local_time, local_date), (central_time, central_date)) = modification_dates(buffer);
+    assert_eq!((local_time, local_date), (central_time, central_date));
+
+    let date = ZipDateTime { date: local_date, time: local_time };
+    let now = Offset::UTC.to_datetime(Timestamp::now());
+
+    assert_eq!(i32::from(now.year()), date.year());
+    assert_ne!(ZipDateTime::default(), date);
+}
+
+#[cfg(not(feature = "jiff-02"))]
 #[tokio::test]
 async fn default_modification_date_is_valid_for_whole_writes() {
     let mut buffer = Vec::new();
@@ -66,6 +91,7 @@ async fn default_modification_date_is_valid_for_whole_writes() {
     assert_default_modification_date(&buffer);
 }
 
+#[cfg(not(feature = "jiff-02"))]
 #[tokio::test]
 async fn default_modification_date_is_valid_for_stream_writes() {
     let mut buffer = Vec::new();
@@ -78,6 +104,34 @@ async fn default_modification_date_is_valid_for_stream_writes() {
     writer.close().await.unwrap();
 
     assert_default_modification_date(&buffer);
+}
+
+#[cfg(feature = "jiff-02")]
+#[tokio::test]
+async fn default_modification_date_uses_current_time_for_whole_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    writer.write_entry_whole(entry, b"data").await.unwrap();
+    writer.close().await.unwrap();
+
+    assert_current_modification_date(&buffer);
+}
+
+#[cfg(feature = "jiff-02")]
+#[tokio::test]
+async fn default_modification_date_uses_current_time_for_stream_writes() {
+    let mut buffer = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut buffer);
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_stream(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+    writer.close().await.unwrap();
+
+    assert_current_modification_date(&buffer);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Replace the optional `chrono` timestamp support with an optional `jiff` feature, matching the sync `zip` crate's Jiff-facing API direction.

When `jiff` is enabled, new `ZipEntry` values now default their last-modified timestamp to the current UTC time via Jiff. When it is disabled, writes keep using the deterministic MS-DOS epoch timestamp of `1980-01-01 00:00:00`.

This keeps `ZipDateTime::default()` deterministic while adding `ZipDateTime::default_for_write()` for feature-sensitive write defaults.

## Changes

- Replace the `chrono` feature/dependency with optional `jiff`.
- Add `ZipDateTime::{as_jiff, from_jiff}` and Jiff conversion impls behind `jiff`.
- Use `ZipDateTime::default_for_write()` when constructing new entries.
- Keep the dev `zip` dependency from enabling its default timestamp/compression feature set.
- Add coverage for deterministic defaults without Jiff and current-time defaults with Jiff.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib default_`
- `cargo test --lib --features jiff default_`
- `cargo test --lib`
- `cargo test --lib --all-features`
- `cargo check --no-default-features --features full-wasm --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --lib --all-features -- -D warnings`
