### PR TITLE
Add seekable streaming ZIP writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral_async_zip"
-version = "0.0.18-rc3"
+version = "0.0.18-rc4"
 edition = "2021"
 authors = ["Harry [hello@majored.pw]"]
 repository = "https://github.com/astral-sh/rs-async-zip"

--- a/src/base/write/entry_seekable.rs
+++ b/src/base/write/entry_seekable.rs
@@ -97,12 +97,21 @@ impl<'b, W: AsyncWrite + AsyncSeek + Unpin> EntrySeekableWriter<'b, W> {
             if !writer.is_zip64 {
                 writer.is_zip64 = true;
             }
-            entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformationExtraField {
-                uncompressed_size: Some(entry.uncompressed_size),
-                compressed_size: Some(entry.compressed_size),
-                relative_header_offset: None,
-                disk_start_number: None,
-            }));
+            // Reserve Zip64 size slots up front so the later header patch stays the same width.
+            match get_zip64_extra_field_mut(&mut entry.extra_fields) {
+                Some(zip64) => {
+                    zip64.uncompressed_size = Some(entry.uncompressed_size);
+                    zip64.compressed_size = Some(entry.compressed_size);
+                }
+                None => {
+                    entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformationExtraField {
+                        uncompressed_size: Some(entry.uncompressed_size),
+                        compressed_size: Some(entry.compressed_size),
+                        relative_header_offset: None,
+                        disk_start_number: None,
+                    }));
+                }
+            }
         }
 
         let utf8_without_alternative =

--- a/src/base/write/entry_seekable.rs
+++ b/src/base/write/entry_seekable.rs
@@ -1,0 +1,320 @@
+// MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
+
+use crate::base::read::get_zip64_extra_field_mut;
+use crate::base::write::compressed_writer::CompressedAsyncWriter;
+use crate::base::write::get_or_put_info_zip_unicode_comment_extra_field_mut;
+use crate::base::write::get_or_put_info_zip_unicode_path_extra_field_mut;
+use crate::base::write::io::offset::AsyncOffsetWriter;
+use crate::base::write::{CentralDirectoryEntry, ZipFileWriter};
+use crate::entry::ZipEntry;
+use crate::error::{Result, Zip64ErrorCase, ZipError};
+use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
+use crate::spec::extra_field::ExtraFieldAsBytes;
+use crate::spec::header::{
+    CentralDirectoryRecord, ExtraField, GeneralPurposeFlag, InfoZipUnicodeCommentExtraField,
+    InfoZipUnicodePathExtraField, LocalFileHeader, Zip64ExtendedInformationExtraField,
+};
+use crate::StringEncoding;
+
+use crc32fast::Hasher;
+use futures_lite::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, SeekFrom};
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+const ZIP64_VERSION_NEEDED: u16 = 45;
+
+/// An entry writer which streams data to a seekable ZIP output.
+///
+/// Unlike [`EntryStreamWriter`](crate::base::write::EntryStreamWriter), this writer doesn't use
+/// data descriptors. Instead, it writes a placeholder local file header, streams the entry data,
+/// then seeks back and patches the header with the final CRC and sizes.
+///
+/// If the final compressed or uncompressed size requires Zip64 but no Zip64 size fields were
+/// reserved up front, closing this writer will fail. Use [`ZipEntryBuilder::size`] to reserve those
+/// fields when the size is known to exceed the non-Zip64 limit, or use
+/// [`ZipFileWriter::write_entry_stream`] for fully unknown Zip64-sized entries.
+///
+/// [`ZipEntryBuilder::size`]: crate::ZipEntryBuilder::size
+pub struct EntrySeekableWriter<'b, W: AsyncWrite + AsyncSeek + Unpin> {
+    writer: AsyncOffsetWriter<CompressedAsyncWriter<'b, W>>,
+    cd_entries: &'b mut Vec<CentralDirectoryEntry>,
+    entry: ZipEntry,
+    hasher: Hasher,
+    lfh: LocalFileHeader,
+    lfh_offset: u64,
+    data_offset: u64,
+    local_header_has_zip64_sizes: bool,
+    force_no_zip64: bool,
+    /// To write back to the original writer if Zip64 is required.
+    is_zip64: &'b mut bool,
+}
+
+impl<'b, W: AsyncWrite + AsyncSeek + Unpin> EntrySeekableWriter<'b, W> {
+    pub(crate) async fn from_raw(
+        writer: &'b mut ZipFileWriter<W>,
+        mut entry: ZipEntry,
+    ) -> Result<EntrySeekableWriter<'b, W>> {
+        if writer.force_no_zip64 && writer.cd_entries.len() >= NON_ZIP64_MAX_NUM_FILES as usize {
+            return Err(ZipError::Zip64Needed(Zip64ErrorCase::TooManyFiles));
+        }
+
+        #[cfg(feature = "deflate64")]
+        if matches!(entry.compression(), crate::Compression::Deflate64) {
+            return Err(ZipError::FeatureNotSupported("Deflate64 writing"));
+        }
+
+        let lfh_offset = writer.writer.offset();
+        let (lfh, local_header_has_zip64_sizes) = EntrySeekableWriter::write_lfh(writer, &mut entry).await?;
+        let data_offset = writer.writer.offset();
+        let force_no_zip64 = writer.force_no_zip64;
+
+        let cd_entries = &mut writer.cd_entries;
+        let is_zip64 = &mut writer.is_zip64;
+        let writer = AsyncOffsetWriter::new(CompressedAsyncWriter::from_raw(&mut writer.writer, entry.compression())?);
+
+        Ok(EntrySeekableWriter {
+            writer,
+            cd_entries,
+            entry,
+            lfh,
+            lfh_offset,
+            data_offset,
+            local_header_has_zip64_sizes,
+            hasher: Hasher::new(),
+            force_no_zip64,
+            is_zip64,
+        })
+    }
+
+    async fn write_lfh(writer: &'b mut ZipFileWriter<W>, entry: &mut ZipEntry) -> Result<(LocalFileHeader, bool)> {
+        let local_header_has_zip64_sizes =
+            entry.uncompressed_size > NON_ZIP64_MAX_SIZE as u64 || entry.compressed_size > NON_ZIP64_MAX_SIZE as u64;
+        if local_header_has_zip64_sizes {
+            if writer.force_no_zip64 {
+                return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+            }
+            if !writer.is_zip64 {
+                writer.is_zip64 = true;
+            }
+            entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(Zip64ExtendedInformationExtraField {
+                uncompressed_size: Some(entry.uncompressed_size),
+                compressed_size: Some(entry.compressed_size),
+                relative_header_offset: None,
+                disk_start_number: None,
+            }));
+        }
+
+        let utf8_without_alternative =
+            entry.filename().is_utf8_without_alternative() && entry.comment().is_utf8_without_alternative();
+        if !utf8_without_alternative {
+            if matches!(entry.filename().encoding(), StringEncoding::Utf8) {
+                let u_file_name = entry.filename().as_bytes().to_vec();
+                if !u_file_name.is_empty() {
+                    let basic_crc32 =
+                        crc32fast::hash(entry.filename().alternative().unwrap_or_else(|| entry.filename().as_bytes()));
+                    let upath_field = get_or_put_info_zip_unicode_path_extra_field_mut(entry.extra_fields.as_mut());
+                    if let InfoZipUnicodePathExtraField::V1 { crc32, unicode } = upath_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_file_name;
+                    }
+                }
+            }
+            if matches!(entry.comment().encoding(), StringEncoding::Utf8) {
+                let u_comment = entry.comment().as_bytes().to_vec();
+                if !u_comment.is_empty() {
+                    let basic_crc32 =
+                        crc32fast::hash(entry.comment().alternative().unwrap_or_else(|| entry.comment().as_bytes()));
+                    let ucom_field = get_or_put_info_zip_unicode_comment_extra_field_mut(entry.extra_fields.as_mut());
+                    if let InfoZipUnicodeCommentExtraField::V1 { crc32, unicode } = ucom_field {
+                        *crc32 = basic_crc32;
+                        *unicode = u_comment;
+                    }
+                }
+            }
+        }
+
+        let filename_basic = entry.filename().alternative().unwrap_or_else(|| entry.filename().as_bytes());
+
+        let lfh = LocalFileHeader {
+            compressed_size: if local_header_has_zip64_sizes { NON_ZIP64_MAX_SIZE } else { 0 },
+            uncompressed_size: if local_header_has_zip64_sizes { NON_ZIP64_MAX_SIZE } else { 0 },
+            compression: entry.compression().into(),
+            crc: entry.crc32,
+            extra_field_length: entry
+                .extra_fields()
+                .count_bytes()
+                .try_into()
+                .map_err(|_| ZipError::ExtraFieldTooLarge)?,
+            file_name_length: filename_basic.len().try_into().map_err(|_| ZipError::FileNameTooLarge)?,
+            mod_time: entry.last_modification_date().time,
+            mod_date: entry.last_modification_date().date,
+            version: crate::spec::version::as_needed_to_extract(entry),
+            flags: GeneralPurposeFlag {
+                data_descriptor: false,
+                encrypted: false,
+                filename_unicode: utf8_without_alternative,
+            },
+        };
+
+        writer.writer.write_all(&crate::spec::consts::LFH_SIGNATURE.to_le_bytes()).await?;
+        writer.writer.write_all(&lfh.as_slice()).await?;
+        writer.writer.write_all(filename_basic).await?;
+        writer.writer.write_all(&entry.extra_fields().as_bytes()).await?;
+
+        Ok((lfh, local_header_has_zip64_sizes))
+    }
+
+    /// Consumes this entry writer and completes all closing tasks.
+    ///
+    /// This includes:
+    /// - Finalising the CRC32 hash value for the written data.
+    /// - Calculating the compressed and uncompressed byte sizes.
+    /// - Seeking back to patch the local file header.
+    /// - Constructing a central directory header.
+    /// - Pushing that central directory header to the [`ZipFileWriter`]'s store.
+    ///
+    /// Failure to call this function before going out of scope would result in a corrupted ZIP file.
+    pub async fn close(mut self) -> Result<()> {
+        self.writer.close().await?;
+
+        let crc = self.hasher.finalize();
+        let uncompressed_size = self.writer.offset();
+        let inner_writer = self.writer.into_inner().into_inner();
+        let compressed_size = inner_writer.offset() - self.data_offset;
+        let end_offset = inner_writer.offset();
+
+        let requires_zip64_sizes =
+            uncompressed_size > NON_ZIP64_MAX_SIZE as u64 || compressed_size > NON_ZIP64_MAX_SIZE as u64;
+        let requires_zip64_offset = self.lfh_offset > NON_ZIP64_MAX_SIZE as u64;
+
+        if self.force_no_zip64 && (requires_zip64_sizes || requires_zip64_offset) {
+            return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+        }
+        if requires_zip64_sizes && !self.local_header_has_zip64_sizes {
+            return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
+        }
+
+        let uses_zip64_sizes = requires_zip64_sizes || self.local_header_has_zip64_sizes;
+        let uses_zip64_metadata = uses_zip64_sizes || requires_zip64_offset;
+        if uses_zip64_sizes {
+            if !*self.is_zip64 {
+                *self.is_zip64 = true;
+            }
+            self.lfh.compressed_size = NON_ZIP64_MAX_SIZE;
+            self.lfh.uncompressed_size = NON_ZIP64_MAX_SIZE;
+            match get_zip64_extra_field_mut(&mut self.entry.extra_fields) {
+                Some(zip64) => {
+                    zip64.uncompressed_size = Some(uncompressed_size);
+                    zip64.compressed_size = Some(compressed_size);
+                }
+                None => {
+                    self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(
+                        Zip64ExtendedInformationExtraField {
+                            uncompressed_size: Some(uncompressed_size),
+                            compressed_size: Some(compressed_size),
+                            relative_header_offset: None,
+                            disk_start_number: None,
+                        },
+                    ));
+                }
+            }
+        } else {
+            self.lfh.compressed_size = compressed_size as u32;
+            self.lfh.uncompressed_size = uncompressed_size as u32;
+        }
+        if uses_zip64_metadata {
+            self.lfh.version = self.lfh.version.max(ZIP64_VERSION_NEEDED);
+        }
+        self.lfh.crc = crc;
+        self.lfh.extra_field_length =
+            self.entry.extra_fields().count_bytes().try_into().map_err(|_| ZipError::ExtraFieldTooLarge)?;
+
+        let filename_basic = self.entry.filename().alternative().unwrap_or_else(|| self.entry.filename().as_bytes());
+        let local_extra_fields = self.entry.extra_fields().as_bytes();
+
+        inner_writer.seek(SeekFrom::Start(self.lfh_offset + crate::spec::consts::SIGNATURE_LENGTH as u64)).await?;
+        inner_writer.write_all(&self.lfh.as_slice()).await?;
+        inner_writer.write_all(filename_basic).await?;
+        inner_writer.write_all(&local_extra_fields).await?;
+        inner_writer.seek(SeekFrom::Start(end_offset)).await?;
+
+        let lh_offset = if requires_zip64_offset {
+            if !*self.is_zip64 {
+                *self.is_zip64 = true;
+            }
+            match get_zip64_extra_field_mut(&mut self.entry.extra_fields) {
+                Some(zip64) => {
+                    zip64.relative_header_offset = Some(self.lfh_offset);
+                }
+                None => {
+                    self.entry.extra_fields.push(ExtraField::Zip64ExtendedInformation(
+                        Zip64ExtendedInformationExtraField {
+                            uncompressed_size: None,
+                            compressed_size: None,
+                            relative_header_offset: Some(self.lfh_offset),
+                            disk_start_number: None,
+                        },
+                    ));
+                }
+            }
+            NON_ZIP64_MAX_SIZE
+        } else {
+            self.lfh_offset as u32
+        };
+
+        let comment_basic = self.entry.comment().alternative().unwrap_or_else(|| self.entry.comment().as_bytes());
+
+        let cdh = CentralDirectoryRecord {
+            compressed_size: self.lfh.compressed_size,
+            uncompressed_size: self.lfh.uncompressed_size,
+            crc,
+            v_made_by: crate::spec::version::as_made_by(),
+            v_needed: self.lfh.version,
+            compression: self.lfh.compression,
+            extra_field_length: self
+                .entry
+                .extra_fields()
+                .count_bytes()
+                .try_into()
+                .map_err(|_| ZipError::ExtraFieldTooLarge)?,
+            file_name_length: self.lfh.file_name_length,
+            file_comment_length: comment_basic.len().try_into().map_err(|_| ZipError::CommentTooLarge)?,
+            mod_time: self.lfh.mod_time,
+            mod_date: self.lfh.mod_date,
+            flags: self.lfh.flags,
+            disk_start: 0,
+            inter_attr: self.entry.internal_file_attribute(),
+            exter_attr: self.entry.external_file_attribute(),
+            lh_offset,
+        };
+
+        self.cd_entries.push(CentralDirectoryEntry { header: cdh, entry: self.entry });
+        // Mark the archive as Zip64 once the central directory no longer fits in the legacy count field.
+        if self.cd_entries.len() > NON_ZIP64_MAX_NUM_FILES as usize && !*self.is_zip64 {
+            *self.is_zip64 = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, W: AsyncWrite + AsyncSeek + Unpin> AsyncWrite for EntrySeekableWriter<'a, W> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        let poll = Pin::new(&mut self.writer).poll_write(cx, buf);
+
+        if let Poll::Ready(Ok(written)) = poll {
+            self.hasher.update(&buf[0..written]);
+        }
+
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(&mut self.writer).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(&mut self.writer).poll_close(cx)
+    }
+}

--- a/src/base/write/entry_seekable.rs
+++ b/src/base/write/entry_seekable.rs
@@ -89,7 +89,7 @@ impl<'b, W: AsyncWrite + AsyncSeek + Unpin> EntrySeekableWriter<'b, W> {
 
     async fn write_lfh(writer: &'b mut ZipFileWriter<W>, entry: &mut ZipEntry) -> Result<(LocalFileHeader, bool)> {
         let local_header_has_zip64_sizes =
-            entry.uncompressed_size > NON_ZIP64_MAX_SIZE as u64 || entry.compressed_size > NON_ZIP64_MAX_SIZE as u64;
+            entry.uncompressed_size >= NON_ZIP64_MAX_SIZE as u64 || entry.compressed_size >= NON_ZIP64_MAX_SIZE as u64;
         if local_header_has_zip64_sizes {
             if writer.force_no_zip64 {
                 return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));
@@ -185,8 +185,8 @@ impl<'b, W: AsyncWrite + AsyncSeek + Unpin> EntrySeekableWriter<'b, W> {
         let end_offset = inner_writer.offset();
 
         let requires_zip64_sizes =
-            uncompressed_size > NON_ZIP64_MAX_SIZE as u64 || compressed_size > NON_ZIP64_MAX_SIZE as u64;
-        let requires_zip64_offset = self.lfh_offset > NON_ZIP64_MAX_SIZE as u64;
+            uncompressed_size >= NON_ZIP64_MAX_SIZE as u64 || compressed_size >= NON_ZIP64_MAX_SIZE as u64;
+        let requires_zip64_offset = self.lfh_offset >= NON_ZIP64_MAX_SIZE as u64;
 
         if self.force_no_zip64 && (requires_zip64_sizes || requires_zip64_offset) {
             return Err(ZipError::Zip64Needed(Zip64ErrorCase::LargeFile));

--- a/src/base/write/io/offset.rs
+++ b/src/base/write/io/offset.rs
@@ -5,7 +5,7 @@ use std::io::{Error, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_lite::io::AsyncWrite;
+use futures_lite::io::{AsyncSeek, AsyncWrite, SeekFrom};
 use pin_project::pin_project;
 
 /// A wrapper around an [`AsyncWrite`] implementation which tracks the current byte offset.
@@ -69,5 +69,21 @@ where
         bufs: &[IoSlice<'_>],
     ) -> Poll<Result<usize, Error>> {
         self.project().inner.poll_write_vectored(cx, bufs)
+    }
+}
+
+impl<W> AsyncSeek for AsyncOffsetWriter<W>
+where
+    W: AsyncWrite + AsyncSeek + Unpin,
+{
+    fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<Result<u64, Error>> {
+        let this = self.project();
+        let poll = this.inner.poll_seek(cx, pos);
+
+        if let Poll::Ready(Ok(offset)) = &poll {
+            *this.offset = *offset;
+        }
+
+        poll
     }
 }

--- a/src/base/write/mod.rs
+++ b/src/base/write/mod.rs
@@ -50,10 +50,12 @@
 //! ```
 
 pub(crate) mod compressed_writer;
+pub(crate) mod entry_seekable;
 pub(crate) mod entry_stream;
 pub(crate) mod entry_whole;
 pub(crate) mod io;
 
+pub use entry_seekable::EntrySeekableWriter;
 pub use entry_stream::EntryStreamWriter;
 
 #[cfg(feature = "tokio")]
@@ -74,7 +76,7 @@ use entry_whole::EntryWholeWriter;
 use io::offset::AsyncOffsetWriter;
 
 use crate::spec::consts::{NON_ZIP64_MAX_NUM_FILES, NON_ZIP64_MAX_SIZE};
-use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+use futures_lite::io::{AsyncSeek, AsyncWrite, AsyncWriteExt};
 
 pub(crate) struct CentralDirectoryEntry {
     pub header: CentralDirectoryRecord,
@@ -131,6 +133,17 @@ impl<W: AsyncWrite + Unpin> ZipFileWriter<W> {
     /// and a null CRC. This might cause problems with the destination reader.
     pub async fn write_entry_stream<E: Into<ZipEntry>>(&mut self, entry: E) -> Result<EntryStreamWriter<'_, W>> {
         EntryStreamWriter::from_raw(self, entry.into()).await
+    }
+
+    /// Write an entry of unknown size and data via streaming to a seekable output.
+    ///
+    /// This avoids data descriptors by seeking back to patch the local file header after
+    /// the entry is written.
+    pub async fn write_entry_seekable<E: Into<ZipEntry>>(&mut self, entry: E) -> Result<EntrySeekableWriter<'_, W>>
+    where
+        W: AsyncSeek,
+    {
+        EntrySeekableWriter::from_raw(self, entry.into()).await
     }
 
     /// Set the ZIP file comment.

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -1,16 +1,17 @@
 // Copyright (c) 2022 Harry [Majored] [hello@majored.pw]
 // MIT License (https://github.com/Majored/rs-async-zip/blob/main/LICENSE)
 
-use futures_lite::io::{AsyncWrite, AsyncWriteExt};
+use futures_lite::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, Cursor, SeekFrom};
 #[cfg(feature = "jiff")]
 use jiff::{tz::Offset, Timestamp};
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::base::write::{central_directory_size_field, ZipFileWriter};
 use crate::error::{Zip64ErrorCase, ZipError};
-use crate::spec::consts::{CDH_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE};
+use crate::spec::consts::{CDH_SIGNATURE, DATA_DESCRIPTOR_SIGNATURE, LFH_SIGNATURE, NON_ZIP64_MAX_SIZE};
+use crate::spec::header::ExtraField;
 #[cfg(feature = "jiff")]
 use crate::ZipDateTime;
 use crate::{Compression, ZipEntryBuilder};
@@ -34,6 +35,53 @@ impl AsyncWrite for AsyncSink {
 
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
+    }
+}
+
+/// /dev/null for AsyncWrite + AsyncSeek.
+#[derive(Default)]
+pub(crate) struct SeekableAsyncSink {
+    position: u64,
+    writes: Vec<(u64, Vec<u8>)>,
+}
+
+impl SeekableAsyncSink {
+    fn bytes_written_at(&self, offset: u64) -> Option<&[u8]> {
+        self.writes.iter().rev().find(|(write_offset, _)| *write_offset == offset).map(|(_, bytes)| bytes.as_slice())
+    }
+}
+
+impl AsyncWrite for SeekableAsyncSink {
+    fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        let position = self.position;
+        self.writes.push((position, buf.to_vec()));
+        self.position += buf.len() as u64;
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncSeek for SeekableAsyncSink {
+    fn poll_seek(mut self: Pin<&mut Self>, _: &mut Context<'_>, pos: SeekFrom) -> Poll<Result<u64, Error>> {
+        let position = match pos {
+            SeekFrom::Start(position) => position,
+            SeekFrom::End(offset) | SeekFrom::Current(offset) => {
+                let position = self.position as i128 + offset as i128;
+                if position < 0 || position > u64::MAX as i128 {
+                    return Poll::Ready(Err(Error::new(ErrorKind::InvalidInput, "invalid seek")));
+                }
+                position as u64
+            }
+        };
+        self.position = position;
+        Poll::Ready(Ok(position))
     }
 }
 
@@ -64,6 +112,41 @@ fn modification_dates(buffer: &[u8]) -> ((u16, u16), (u16, u16)) {
         u16::from_le_bytes(buffer[central_directory_offset + 14..central_directory_offset + 16].try_into().unwrap());
 
     ((local_time, local_date), (central_time, central_date))
+}
+
+fn compact_entry_headers(buffer: &[u8]) -> ((u16, u16), (u16, u16)) {
+    let local_header_signature = LFH_SIGNATURE.to_le_bytes();
+    assert_eq!(&buffer[..local_header_signature.len()], local_header_signature);
+    let local_flags = u16::from_le_bytes(buffer[6..8].try_into().unwrap());
+    let local_extra_length = u16::from_le_bytes(buffer[28..30].try_into().unwrap());
+
+    let central_directory_signature = CDH_SIGNATURE.to_le_bytes();
+    let central_directory_offset = buffer
+        .windows(central_directory_signature.len())
+        .position(|window| window == central_directory_signature)
+        .unwrap();
+    let central_flags =
+        u16::from_le_bytes(buffer[central_directory_offset + 8..central_directory_offset + 10].try_into().unwrap());
+    let central_extra_length =
+        u16::from_le_bytes(buffer[central_directory_offset + 30..central_directory_offset + 32].try_into().unwrap());
+
+    ((local_flags, local_extra_length), (central_flags, central_extra_length))
+}
+
+fn entry_versions(buffer: &[u8]) -> (u16, u16) {
+    let local_header_signature = LFH_SIGNATURE.to_le_bytes();
+    assert_eq!(&buffer[..local_header_signature.len()], local_header_signature);
+    let local_version = u16::from_le_bytes(buffer[4..6].try_into().unwrap());
+
+    let central_directory_signature = CDH_SIGNATURE.to_le_bytes();
+    let central_directory_offset = buffer
+        .windows(central_directory_signature.len())
+        .position(|window| window == central_directory_signature)
+        .unwrap();
+    let central_version =
+        u16::from_le_bytes(buffer[central_directory_offset + 6..central_directory_offset + 8].try_into().unwrap());
+
+    (local_version, central_version)
 }
 
 #[cfg(feature = "jiff")]
@@ -106,6 +189,20 @@ async fn default_modification_date_is_valid_for_stream_writes() {
     assert_default_modification_date(&buffer);
 }
 
+#[cfg(not(feature = "jiff"))]
+#[tokio::test]
+async fn default_modification_date_is_valid_for_seekable_stream_writes() {
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+    let buffer = writer.close().await.unwrap().into_inner();
+
+    assert_default_modification_date(&buffer);
+}
+
 #[cfg(feature = "jiff")]
 #[tokio::test]
 async fn default_modification_date_uses_current_time_for_whole_writes() {
@@ -132,6 +229,153 @@ async fn default_modification_date_uses_current_time_for_stream_writes() {
     writer.close().await.unwrap();
 
     assert_current_modification_date(&buffer);
+}
+
+#[cfg(feature = "jiff")]
+#[tokio::test]
+async fn default_modification_date_uses_current_time_for_seekable_stream_writes() {
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+    let buffer = writer.close().await.unwrap().into_inner();
+
+    assert_current_modification_date(&buffer);
+}
+
+#[tokio::test]
+async fn seekable_stream_writes_compact_headers() {
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+    let buffer = writer.close().await.unwrap().into_inner();
+
+    let ((local_flags, local_extra_length), (central_flags, central_extra_length)) = compact_entry_headers(&buffer);
+    assert_eq!(local_flags & (1 << 3), 0);
+    assert_eq!(central_flags & (1 << 3), 0);
+    assert_eq!(local_extra_length, 0);
+    assert_eq!(central_extra_length, 0);
+
+    let data_descriptor_signature = DATA_DESCRIPTOR_SIGNATURE.to_le_bytes();
+    assert!(!buffer.windows(data_descriptor_signature.len()).any(|window| window == data_descriptor_signature));
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    let mut file = zip.by_name("file").unwrap();
+    let mut contents = Vec::new();
+    std::io::Read::read_to_end(&mut file, &mut contents).unwrap();
+    assert_eq!(contents, b"data");
+}
+
+#[tokio::test]
+async fn seekable_stream_updates_reserved_zip64_sizes_when_actual_size_fits() {
+    let data = b"data";
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored)
+        .size(NON_ZIP64_MAX_SIZE as u64 + 1, NON_ZIP64_MAX_SIZE as u64 + 1);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(data).await.unwrap();
+    entry_writer.close().await.unwrap();
+
+    assert!(writer.is_zip64);
+    let cd_entry = writer.cd_entries.last().unwrap();
+    assert_eq!(cd_entry.header.compressed_size, NON_ZIP64_MAX_SIZE);
+    assert_eq!(cd_entry.header.uncompressed_size, NON_ZIP64_MAX_SIZE);
+    match cd_entry.entry.extra_fields().last().unwrap() {
+        ExtraField::Zip64ExtendedInformation(zip64) => {
+            assert_eq!(zip64.compressed_size, Some(data.len() as u64));
+            assert_eq!(zip64.uncompressed_size, Some(data.len() as u64));
+        }
+        field => panic!("Expected a Zip64 extended field, got {field:?}"),
+    }
+
+    let buffer = writer.close().await.unwrap().into_inner();
+    let (local_version, central_version) = entry_versions(&buffer);
+    assert_eq!(local_version, 45);
+    assert_eq!(central_version, 45);
+    assert_eq!(u32::from_le_bytes(buffer[18..22].try_into().unwrap()), NON_ZIP64_MAX_SIZE);
+    assert_eq!(u32::from_le_bytes(buffer[22..26].try_into().unwrap()), NON_ZIP64_MAX_SIZE);
+
+    let central_directory_offset = buffer
+        .windows(CDH_SIGNATURE.to_le_bytes().len())
+        .position(|window| window == CDH_SIGNATURE.to_le_bytes())
+        .unwrap();
+    assert_eq!(
+        u32::from_le_bytes(buffer[central_directory_offset + 20..central_directory_offset + 24].try_into().unwrap()),
+        NON_ZIP64_MAX_SIZE,
+    );
+    assert_eq!(
+        u32::from_le_bytes(buffer[central_directory_offset + 24..central_directory_offset + 28].try_into().unwrap()),
+        NON_ZIP64_MAX_SIZE,
+    );
+
+    let reader = crate::base::read::mem::ZipFileReader::new(buffer).await.unwrap();
+    assert!(reader.file().zip64);
+    assert_eq!(reader.file().entries[0].entry.compressed_size, data.len() as u64);
+    assert_eq!(reader.file().entries[0].entry.uncompressed_size, data.len() as u64);
+}
+
+#[tokio::test]
+async fn seekable_stream_raises_version_needed_for_zip64_local_header_offset() {
+    let mut writer = ZipFileWriter::new(SeekableAsyncSink::default());
+    writer.writer.seek(SeekFrom::Start(NON_ZIP64_MAX_SIZE as u64 + 1)).await.unwrap();
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+
+    assert!(writer.is_zip64);
+    let local_header = writer
+        .writer
+        .inner_mut()
+        .bytes_written_at(NON_ZIP64_MAX_SIZE as u64 + 1 + LFH_SIGNATURE.to_le_bytes().len() as u64)
+        .unwrap();
+    assert_eq!(u16::from_le_bytes(local_header[0..2].try_into().unwrap()), 45);
+    let cd_entry = writer.cd_entries.last().unwrap();
+    assert_eq!(cd_entry.header.v_needed, 45);
+    assert_eq!(cd_entry.header.lh_offset, NON_ZIP64_MAX_SIZE);
+    match cd_entry.entry.extra_fields().last().unwrap() {
+        ExtraField::Zip64ExtendedInformation(zip64) => {
+            assert_eq!(zip64.compressed_size, None);
+            assert_eq!(zip64.uncompressed_size, None);
+            assert_eq!(zip64.relative_header_offset, Some(NON_ZIP64_MAX_SIZE as u64 + 1));
+        }
+        field => panic!("Expected a Zip64 extended field, got {field:?}"),
+    }
+
+    writer.close().await.unwrap();
+}
+
+#[cfg(feature = "deflate")]
+#[tokio::test]
+async fn seekable_stream_deflate_writes_compact_headers() {
+    let contents = b"repeated data ".repeat(128);
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Deflate);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(&contents).await.unwrap();
+    entry_writer.close().await.unwrap();
+    let buffer = writer.close().await.unwrap().into_inner();
+
+    let ((local_flags, local_extra_length), (central_flags, central_extra_length)) = compact_entry_headers(&buffer);
+    assert_eq!(local_flags & (1 << 3), 0);
+    assert_eq!(central_flags & (1 << 3), 0);
+    assert_eq!(local_extra_length, 0);
+    assert_eq!(central_extra_length, 0);
+
+    let reader = crate::base::read::mem::ZipFileReader::new(buffer).await.unwrap();
+    let mut entry = reader.reader_without_entry(0).await.unwrap();
+    let mut actual = Vec::new();
+    futures_lite::io::AsyncReadExt::read_to_end(&mut entry, &mut actual).await.unwrap();
+    assert_eq!(actual, contents);
 }
 
 #[tokio::test]
@@ -170,6 +414,17 @@ async fn reject_deflate64_stream_writes() {
 
     assert!(matches!(result, Err(ZipError::FeatureNotSupported("Deflate64 writing"))));
     assert!(buffer.is_empty());
+}
+
+#[cfg(feature = "deflate64")]
+#[tokio::test]
+async fn reject_deflate64_seekable_stream_writes() {
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Deflate64);
+
+    let result = writer.write_entry_seekable(entry).await;
+
+    assert!(matches!(result, Err(ZipError::FeatureNotSupported("Deflate64 writing"))));
 }
 
 #[test]

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -322,6 +322,30 @@ async fn seekable_stream_updates_reserved_zip64_sizes_when_actual_size_fits() {
 }
 
 #[tokio::test]
+async fn seekable_stream_reserves_zip64_sizes_at_legacy_sentinel() {
+    let data = b"data";
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored)
+        .size(NON_ZIP64_MAX_SIZE as u64, NON_ZIP64_MAX_SIZE as u64);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(data).await.unwrap();
+    entry_writer.close().await.unwrap();
+
+    assert!(writer.is_zip64);
+    let cd_entry = writer.cd_entries.last().unwrap();
+    assert_eq!(cd_entry.header.compressed_size, NON_ZIP64_MAX_SIZE);
+    assert_eq!(cd_entry.header.uncompressed_size, NON_ZIP64_MAX_SIZE);
+    match cd_entry.entry.extra_fields().last().unwrap() {
+        ExtraField::Zip64ExtendedInformation(zip64) => {
+            assert_eq!(zip64.compressed_size, Some(data.len() as u64));
+            assert_eq!(zip64.uncompressed_size, Some(data.len() as u64));
+        }
+        field => panic!("Expected a Zip64 extended field, got {field:?}"),
+    }
+}
+
+#[tokio::test]
 async fn seekable_stream_raises_version_needed_for_zip64_local_header_offset() {
     let mut writer = ZipFileWriter::new(SeekableAsyncSink::default());
     writer.writer.seek(SeekFrom::Start(NON_ZIP64_MAX_SIZE as u64 + 1)).await.unwrap();
@@ -346,6 +370,38 @@ async fn seekable_stream_raises_version_needed_for_zip64_local_header_offset() {
             assert_eq!(zip64.compressed_size, None);
             assert_eq!(zip64.uncompressed_size, None);
             assert_eq!(zip64.relative_header_offset, Some(NON_ZIP64_MAX_SIZE as u64 + 1));
+        }
+        field => panic!("Expected a Zip64 extended field, got {field:?}"),
+    }
+
+    writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn seekable_stream_raises_version_needed_at_zip64_local_header_offset_sentinel() {
+    let mut writer = ZipFileWriter::new(SeekableAsyncSink::default());
+    writer.writer.seek(SeekFrom::Start(NON_ZIP64_MAX_SIZE as u64)).await.unwrap();
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(b"data").await.unwrap();
+    entry_writer.close().await.unwrap();
+
+    assert!(writer.is_zip64);
+    let local_header = writer
+        .writer
+        .inner_mut()
+        .bytes_written_at(NON_ZIP64_MAX_SIZE as u64 + LFH_SIGNATURE.to_le_bytes().len() as u64)
+        .unwrap();
+    assert_eq!(u16::from_le_bytes(local_header[0..2].try_into().unwrap()), 45);
+    let cd_entry = writer.cd_entries.last().unwrap();
+    assert_eq!(cd_entry.header.v_needed, 45);
+    assert_eq!(cd_entry.header.lh_offset, NON_ZIP64_MAX_SIZE);
+    match cd_entry.entry.extra_fields().last().unwrap() {
+        ExtraField::Zip64ExtendedInformation(zip64) => {
+            assert_eq!(zip64.compressed_size, None);
+            assert_eq!(zip64.uncompressed_size, None);
+            assert_eq!(zip64.relative_header_offset, Some(NON_ZIP64_MAX_SIZE as u64));
         }
         field => panic!("Expected a Zip64 extended field, got {field:?}"),
     }

--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -346,6 +346,34 @@ async fn seekable_stream_reserves_zip64_sizes_at_legacy_sentinel() {
 }
 
 #[tokio::test]
+async fn seekable_stream_preserves_data_with_existing_zip64_extra_field() {
+    let data = b"data";
+    let mut writer = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("file".into(), Compression::Stored)
+        .size(NON_ZIP64_MAX_SIZE as u64 + 1, NON_ZIP64_MAX_SIZE as u64 + 1)
+        .extra_fields(vec![ExtraField::Zip64ExtendedInformation(
+            crate::spec::header::Zip64ExtendedInformationExtraField {
+                uncompressed_size: None,
+                compressed_size: None,
+                relative_header_offset: None,
+                disk_start_number: None,
+            },
+        )]);
+
+    let mut entry_writer = writer.write_entry_seekable(entry).await.unwrap();
+    entry_writer.write_all(data).await.unwrap();
+    entry_writer.close().await.unwrap();
+    let buffer = writer.close().await.unwrap().into_inner();
+
+    let cursor = std::io::Cursor::new(buffer);
+    let mut zip = zip::read::ZipArchive::new(cursor).unwrap();
+    let mut file = zip.by_name("file").unwrap();
+    let mut contents = Vec::new();
+    std::io::Read::read_to_end(&mut file, &mut contents).unwrap();
+    assert_eq!(contents, data);
+}
+
+#[tokio::test]
 async fn seekable_stream_raises_version_needed_for_zip64_local_header_offset() {
     let mut writer = ZipFileWriter::new(SeekableAsyncSink::default());
     writer.writer.seek(SeekFrom::Start(NON_ZIP64_MAX_SIZE as u64 + 1)).await.unwrap();


### PR DESCRIPTION
## Summary

This avoids some of the bloat that comes from streaming, like data descriptors, speculative Zip64 extras, etc.

See: https://github.com/astral-sh/uv/pull/19383.
