### PR TITLE
Bump version to 0.0.18-rc3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral_async_zip"
-version = "0.0.18-rc2"
+version = "0.0.18-rc3"
 edition = "2021"
 authors = ["Harry [hello@majored.pw]"]
 repository = "https://github.com/astral-sh/rs-async-zip"


### PR DESCRIPTION
## Summary

Bump astral_async_zip from 0.0.18-rc2 to 0.0.18-rc3.

## Testing

- cargo test --all-features
- cargo fmt --check
- cargo clippy --all-features -- -D clippy::all