### PR TITLE
Omit zip64 tests on 32-bit targets

### DIFF
--- a/src/tests/write/mod.rs
+++ b/src/tests/write/mod.rs
@@ -17,6 +17,7 @@ use crate::ZipDateTime;
 use crate::{Compression, ZipEntryBuilder};
 
 pub(crate) mod offset;
+#[cfg(target_pointer_width = "64")]
 mod zip64;
 
 /// /dev/null for AsyncWrite.


### PR DESCRIPTION
In Fedora, we still build `i686` versions of packages by default; most of them are unused in practice since there is no full 32-bit version of the distribution, but some contribute to multilib packages that are shipped to support things like Wine and Steam on `x86_64`. Rather than plastering `ExcludeArch` directives everywhere, it’s easier if our Rust library packages can just build and pass their tests on `i686`, even if they end up not being used there in practice. The small change in this PR makes that possible.