### PR TITLE
Exclude `rustfmt.toml` from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/astral_async_zip/"
 homepage = "https://github.com/astral-sh/rs-async-zip"
 keywords = ["async", "zip", "archive", "tokio"]
 categories = ["asynchronous", "compression"]
+exclude = ["rustfmt.toml"]
 
 [lib]
 name = "async_zip"


### PR DESCRIPTION
It is small (especially compared to the tests and their data) and harmless; still, its inclusion does not benefit crate users *or* downstream packagers.