### PR TITLE
Limit trailing ZIP NUL padding to 4 KiB

### DIFF
--- a/src/base/read/cd.rs
+++ b/src/base/read/cd.rs
@@ -101,8 +101,9 @@ where
     /// reader to the next record.
     ///
     /// Returns `Ok(EndOfCentralDirectoryRecord)` if the end of the central directory record has
-    /// been reached and only optional NUL padding remains before EOF. The source must be finite
-    /// or bounded to a single archive; returning the end record consumes that padding.
+    /// been reached and at most 4 KiB of NUL padding remains before EOF. The source must be finite
+    /// or bounded to a single archive; returning the end record consumes that padding. Zeros in
+    /// the declared comment do not count toward the padding limit.
     pub async fn next(&mut self) -> Result<Entry> {
         // Skip the first `CDH_SIGNATURE`. The `CentralDirectoryReader` is assumed to pick up from
         // where the streaming `ZipFileReader` left off, which means that the first record's

--- a/src/base/read/io/locator.rs
+++ b/src/base/read/io/locator.rs
@@ -25,11 +25,13 @@ use crate::spec::consts::{EOCDR_LENGTH, EOCDR_SIGNATURE, SIGNATURE_LENGTH};
 
 use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
 
+use super::MAX_TRAILING_NUL_BYTES;
+
 /// The buffer size used when locating the EOCDR, equal to 2KiB.
 const BUFFER_SIZE: usize = 2048;
 
-/// The maximum distance from the end of the archive comment to the EOCDR signature.
-const EOCDR_SEARCH_LENGTH: u64 = (EOCDR_LENGTH + SIGNATURE_LENGTH) as u64 + u16::MAX as u64;
+/// The maximum distance from physical EOF to the EOCDR signature, including comment and padding.
+const EOCDR_SEARCH_LENGTH: u64 = (EOCDR_LENGTH + SIGNATURE_LENGTH + MAX_TRAILING_NUL_BYTES) as u64 + u16::MAX as u64;
 
 /// Locate the `end of central directory record` offset, if one exists.
 /// The returned offset excludes the signature (4 bytes)
@@ -44,31 +46,21 @@ pub async fn eocdr<R>(mut reader: R) -> ZipResult<u64>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {
-    let mut end = reader.seek(SeekFrom::End(0)).await?;
+    let end = reader.seek(SeekFrom::End(0)).await?;
     let signature = &EOCDR_SIGNATURE.to_le_bytes();
     let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
 
-    // NUL padding has no length limit. Find the last nonzero byte without allocating for or
-    // changing the source. This is only a search anchor: zeros in the end record or its comment
-    // are still parsed normally, with their declared lengths checked against the physical EOF.
-    let (mut position, mut read) = loop {
-        let position = end.saturating_sub(BUFFER_SIZE as u64);
-        let read = (end - position) as usize;
+    // Bound work even for an all-zero source. The window includes the full declared comment
+    // allowance: its zeros and the end record's zero-valued fields are not suffix padding.
+    // The footer parser checks the actual padding length after reading the declared comment.
+    let lower_bound = end.saturating_sub(EOCDR_SEARCH_LENGTH);
+    let mut position = end.saturating_sub(BUFFER_SIZE as u64);
+
+    loop {
+        let read = BUFFER_SIZE.min((end - position) as usize);
         reader.seek(SeekFrom::Start(position)).await?;
         reader.read_exact(&mut buffer[..read]).await?;
 
-        if let Some(last) = buffer[..read].iter().rposition(|&byte| byte != 0) {
-            end = position + last as u64 + 1;
-            break (position, read);
-        }
-        if position == 0 {
-            return Err(ZipError::UnableToLocateEOCDR);
-        }
-        end = position;
-    };
-    let lower_bound = end.saturating_sub(EOCDR_SEARCH_LENGTH);
-
-    loop {
         if let Some(match_index) = reverse_search_buffer(&buffer[..read], signature) {
             return Ok(position + (match_index + 1) as u64);
         }
@@ -82,9 +74,6 @@ where
         // signature length. This significantly reduces the complexity of handling partial matches with very little
         // overhead.
         position = position.saturating_sub((BUFFER_SIZE - SIGNATURE_LENGTH) as u64).max(lower_bound);
-        reader.seek(SeekFrom::Start(position)).await?;
-        read = BUFFER_SIZE.min((end - position) as usize);
-        reader.read_exact(&mut buffer[..read]).await?;
     }
 }
 

--- a/src/base/read/io/locator.rs
+++ b/src/base/read/io/locator.rs
@@ -28,11 +28,8 @@ use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFro
 /// The buffer size used when locating the EOCDR, equal to 2KiB.
 const BUFFER_SIZE: usize = 2048;
 
-/// The upper bound of where the EOCDR signature cannot be located.
-const EOCDR_UPPER_BOUND: u64 = EOCDR_LENGTH as u64;
-
-/// The lower bound of where the EOCDR signature cannot be located.
-const EOCDR_LOWER_BOUND: u64 = EOCDR_UPPER_BOUND + SIGNATURE_LENGTH as u64 + u16::MAX as u64;
+/// The maximum distance from the end of the archive comment to the EOCDR signature.
+const EOCDR_SEARCH_LENGTH: u64 = (EOCDR_LENGTH + SIGNATURE_LENGTH) as u64 + u16::MAX as u64;
 
 /// Locate the `end of central directory record` offset, if one exists.
 /// The returned offset excludes the signature (4 bytes)
@@ -47,31 +44,47 @@ pub async fn eocdr<R>(mut reader: R) -> ZipResult<u64>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {
-    let length = reader.seek(SeekFrom::End(0)).await?;
+    let mut end = reader.seek(SeekFrom::End(0)).await?;
     let signature = &EOCDR_SIGNATURE.to_le_bytes();
     let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
 
-    let mut position = length.saturating_sub((EOCDR_LENGTH + BUFFER_SIZE) as u64);
-    reader.seek(SeekFrom::Start(position)).await?;
-
-    loop {
-        let read = BUFFER_SIZE.min((length - position) as usize);
+    // NUL padding has no length limit. Find the last nonzero byte without allocating for or
+    // changing the source. This is only a search anchor: zeros in the end record or its comment
+    // are still parsed normally, with their declared lengths checked against the physical EOF.
+    let (mut position, mut read) = loop {
+        let position = end.saturating_sub(BUFFER_SIZE as u64);
+        let read = (end - position) as usize;
+        reader.seek(SeekFrom::Start(position)).await?;
         reader.read_exact(&mut buffer[..read]).await?;
 
+        if let Some(last) = buffer[..read].iter().rposition(|&byte| byte != 0) {
+            end = position + last as u64 + 1;
+            break (position, read);
+        }
+        if position == 0 {
+            return Err(ZipError::UnableToLocateEOCDR);
+        }
+        end = position;
+    };
+    let lower_bound = end.saturating_sub(EOCDR_SEARCH_LENGTH);
+
+    loop {
         if let Some(match_index) = reverse_search_buffer(&buffer[..read], signature) {
             return Ok(position + (match_index + 1) as u64);
         }
 
         // If we hit the start of the data or the lower bound, we're unable to locate the EOCDR.
-        if position == 0 || position <= length.saturating_sub(EOCDR_LOWER_BOUND) {
+        if position <= lower_bound {
             return Err(ZipError::UnableToLocateEOCDR);
         }
 
         // To handle the case where the EOCDR signature crosses buffer boundaries, we simply overlap reads by the
         // signature length. This significantly reduces the complexity of handling partial matches with very little
         // overhead.
-        position = position.saturating_sub((BUFFER_SIZE - SIGNATURE_LENGTH) as u64);
+        position = position.saturating_sub((BUFFER_SIZE - SIGNATURE_LENGTH) as u64).max(lower_bound);
         reader.seek(SeekFrom::Start(position)).await?;
+        read = BUFFER_SIZE.min((end - position) as usize);
+        reader.read_exact(&mut buffer[..read]).await?;
     }
 }
 

--- a/src/base/read/io/mod.rs
+++ b/src/base/read/io/mod.rs
@@ -13,6 +13,9 @@ pub use combined_record::CombinedCentralDirectoryRecord;
 use crate::string::{StringEncoding, ZipString};
 use futures_lite::io::{AsyncRead, AsyncReadExt};
 
+/// Maximum NUL padding after the declared archive comment.
+const MAX_TRAILING_NUL_BYTES: usize = 4096;
+
 /// Read and return a dynamic length string from a reader which impls AsyncRead.
 pub(crate) async fn read_string<R>(reader: R, length: usize, encoding: StringEncoding) -> std::io::Result<ZipString>
 where
@@ -53,15 +56,19 @@ where
     Ok(())
 }
 
-/// Requires EOF after the archive comment, tolerating only trailing NUL padding.
-pub(crate) async fn validate_trailing_contents<R: AsyncRead + Unpin>(mut reader: R) -> crate::error::Result<()> {
+/// Requires EOF after the archive comment, tolerating at most 4 KiB of NUL padding.
+pub(crate) async fn validate_trailing_contents<R: AsyncRead + Unpin>(reader: R) -> crate::error::Result<()> {
+    // Read one byte beyond the limit to distinguish an exact-limit suffix from excess padding.
+    let mut reader = reader.take((MAX_TRAILING_NUL_BYTES + 1) as u64);
     let mut buffer = [0; 8192];
+    let mut padding = 0;
     loop {
         let read = reader.read(&mut buffer).await?;
         if read == 0 {
             return Ok(());
         }
-        if buffer[..read].iter().any(|&byte| byte != 0) {
+        padding += read;
+        if padding > MAX_TRAILING_NUL_BYTES || buffer[..read].iter().any(|&byte| byte != 0) {
             return Err(crate::error::ZipError::TrailingContents);
         }
     }

--- a/src/base/read/seek.rs
+++ b/src/base/read/seek.rs
@@ -54,8 +54,8 @@ where
 {
     /// Constructs a new ZIP reader from a seekable source.
     ///
-    /// The source must be finite or bounded to a single archive. Only NUL padding is permitted
-    /// after the end record's comment. Entry contents are not read during construction.
+    /// The source must be finite or bounded to a single archive. At most 4 KiB of NUL padding is
+    /// permitted after the end record's declared comment. Local headers are not walked during construction.
     pub async fn new(mut reader: R) -> Result<ZipFileReader<R>> {
         let file = crate::base::read::file(&mut reader).await?;
         Ok(ZipFileReader::from_raw_parts(reader, file))

--- a/src/tests/read/cd/mod.rs
+++ b/src/tests/read/cd/mod.rs
@@ -101,25 +101,20 @@ async fn malo_accept_zip64_eocd() {
 }
 
 #[tokio::test]
-async fn trailing_nul_padding_is_accepted() {
-    // Malo has no padding variants; append NULs to its unchanged stored archive.
-    for padding in [0, 1, 256, 1024, 4095, 4096] {
-        let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
-        data.resize(data.len() + padding, 0);
-        for result in archive_results(&data).await {
-            result.unwrap();
+async fn trailing_nul_padding_limit_is_enforced() {
+    // Reuse the same boundary cases across classic ZIP, ZIP64, and all three reader modes.
+    for archive in [
+        include_bytes!("../malo/accept/store.zip").as_slice(),
+        #[cfg(feature = "deflate")]
+        include_bytes!("../malo/accept/zip64_eocd.zip").as_slice(),
+    ] {
+        for padding in [0, 4096, 4097] {
+            let mut data = archive.to_vec();
+            data.resize(data.len() + padding, 0);
+            for result in archive_results(&data).await {
+                assert_eq!(result.is_ok(), padding <= 4096, "{padding} padding bytes: {result:?}");
+            }
         }
-    }
-}
-
-#[tokio::test]
-async fn excessive_trailing_nul_padding_is_rejected() {
-    // Preserve the original fixture and vary only the suffix, including one byte over the cap.
-    for padding in [4097, 8192, 131_072] {
-        let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
-        data.resize(data.len() + padding, 0);
-        let results = archive_results(&data).await;
-        assert!(results.iter().all(Result::is_err), "{padding} padding bytes: {results:?}");
     }
 }
 
@@ -129,14 +124,11 @@ async fn trailing_nul_validation_has_bounded_io() {
     use crate::error::ZipError;
     use futures_lite::io::{repeat, AsyncReadExt};
 
-    for chunk in [1, 3, 8192] {
-        // Bound the zero source in the test itself so the pre-fix regression cannot hang.
-        // Rejection must happen before the artificial EOF and its injected I/O error.
-        let mut reader = super::ShortReader::new(repeat(0).take(8192), chunk).with_eof_error(std::io::ErrorKind::Other);
-        let result = validate_trailing_contents(&mut reader).await;
-        assert!(matches!(result, Err(ZipError::TrailingContents)), "{result:?}");
-        assert_eq!(reader.bytes_read, 4097);
-    }
+    // Short reads must accumulate toward the cap without reaching the artificial EOF.
+    let mut reader = super::ShortReader::new(repeat(0).take(8192), 3).with_eof_error(std::io::ErrorKind::Other);
+    let result = validate_trailing_contents(&mut reader).await;
+    assert!(matches!(result, Err(ZipError::TrailingContents)), "{result:?}");
+    assert_eq!(reader.bytes_read, 4097);
 }
 
 #[tokio::test]

--- a/src/tests/read/cd/mod.rs
+++ b/src/tests/read/cd/mod.rs
@@ -103,12 +103,39 @@ async fn malo_accept_zip64_eocd() {
 #[tokio::test]
 async fn trailing_nul_padding_is_accepted() {
     // Malo has no padding variants; append NULs to its unchanged stored archive.
-    for padding in [0, 1, 256, 1024] {
+    for padding in [0, 1, 256, 1024, 4095, 4096] {
         let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
         data.resize(data.len() + padding, 0);
         for result in archive_results(&data).await {
             result.unwrap();
         }
+    }
+}
+
+#[tokio::test]
+async fn excessive_trailing_nul_padding_is_rejected() {
+    // Preserve the original fixture and vary only the suffix, including one byte over the cap.
+    for padding in [4097, 8192, 131_072] {
+        let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
+        data.resize(data.len() + padding, 0);
+        let results = archive_results(&data).await;
+        assert!(results.iter().all(Result::is_err), "{padding} padding bytes: {results:?}");
+    }
+}
+
+#[tokio::test]
+async fn trailing_nul_validation_has_bounded_io() {
+    use crate::base::read::io::validate_trailing_contents;
+    use crate::error::ZipError;
+    use futures_lite::io::{repeat, AsyncReadExt};
+
+    for chunk in [1, 3, 8192] {
+        // Bound the zero source in the test itself so the pre-fix regression cannot hang.
+        // Rejection must happen before the artificial EOF and its injected I/O error.
+        let mut reader = super::ShortReader::new(repeat(0).take(8192), chunk).with_eof_error(std::io::ErrorKind::Other);
+        let result = validate_trailing_contents(&mut reader).await;
+        assert!(matches!(result, Err(ZipError::TrailingContents)), "{result:?}");
+        assert_eq!(reader.bytes_read, 4097);
     }
 }
 

--- a/src/tests/read/locator/mod.rs
+++ b/src/tests/read/locator/mod.rs
@@ -76,22 +76,25 @@ async fn locator_buffer_boundary_test() {
 }
 
 #[tokio::test]
-async fn locator_accepts_long_nul_padding() {
+async fn locator_accepts_nul_padding_up_to_limit() {
     use crate::base::read::{io::locator::eocdr, mem, seek};
     use futures_lite::io::Cursor;
 
-    // Neither uv nor Malo has long-padding cases. Keep the existing archives intact and append
-    // only padding beyond the maximum EOCD/comment search window, including chunk boundaries.
+    // Append only padding to existing fixtures, including chunk boundaries and the 4 KiB limit.
+    // A zero-filled maximum comment distinguishes declared comment bytes from suffix padding.
+    let mut nul_comment = include_bytes!("empty-with-max-comment.zip").to_vec();
+    nul_comment[22..].fill(0);
     let archives: &[&[u8]] = &[
         include_bytes!("empty.zip"),
         include_bytes!("empty-with-max-comment.zip"),
+        &nul_comment,
         include_bytes!("empty-buffer-boundary.zip"),
         include_bytes!("../malo/accept/store.zip"),
         include_bytes!("../malo/accept/comment.zip"),
     ];
     for &archive in archives {
         let expected = eocdr(Cursor::new(archive)).await.unwrap();
-        for padding in [65_557, 65_558, 67_606] {
+        for padding in [0, 2047, 2048, 2049, 4095, 4096] {
             let mut data = archive.to_vec();
             data.resize(data.len() + padding, 0);
             assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
@@ -103,26 +106,33 @@ async fn locator_accepts_long_nul_padding() {
 
 #[cfg(feature = "deflate")]
 #[tokio::test]
-async fn locator_accepts_long_nul_padding_after_zip64() {
+async fn zip64_nul_padding_limit_is_enforced() {
     use crate::base::read::{io::locator::eocdr, mem, seek};
     use futures_lite::io::Cursor;
 
-    let mut data = include_bytes!("../malo/accept/zip64_eocd.zip").to_vec();
-    let expected = eocdr(Cursor::new(&data)).await.unwrap();
-    data.resize(data.len() + 131_072, 0);
-    assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
-    super::cd::read_streamed_archive(&data[..]).await.unwrap();
-    seek::ZipFileReader::new(Cursor::new(&data)).await.unwrap();
-    mem::ZipFileReader::new(data).await.unwrap();
+    let original = include_bytes!("../malo/accept/zip64_eocd.zip");
+    let expected = eocdr(Cursor::new(original)).await.unwrap();
+    for padding in [4096, 4097] {
+        let mut data = original.to_vec();
+        data.resize(data.len() + padding, 0);
+        assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
+        for result in [
+            super::cd::read_streamed_archive(&data[..]).await,
+            seek::ZipFileReader::new(Cursor::new(&data)).await.map(|_| ()),
+            mem::ZipFileReader::new(data).await.map(|_| ()),
+        ] {
+            assert_eq!(result.is_ok(), padding <= 4096, "{padding} padding bytes: {result:?}");
+        }
+    }
 }
 
 #[tokio::test]
-async fn locator_accepts_long_nul_padding_with_short_reads() {
+async fn locator_accepts_maximum_comment_and_padding_with_short_reads() {
     use crate::base::read::io::locator::eocdr;
     use futures_lite::io::Cursor;
 
-    let mut data = include_bytes!("empty.zip").to_vec();
-    data.resize(data.len() + 65_558, 0);
+    let mut data = include_bytes!("empty-with-max-comment.zip").to_vec();
+    data.resize(data.len() + 4096, 0);
     let reader = super::ShortReader::new(Cursor::new(data), 3);
     assert_eq!(eocdr(reader).await.unwrap(), 4);
 }
@@ -135,8 +145,10 @@ async fn locator_rejects_all_zero_input() {
 
     let mut data = include_bytes!("empty.zip").to_vec();
     data.fill(0);
-    data.resize(65_558, 0);
-    assert!(matches!(eocdr(Cursor::new(data)).await, Err(ZipError::UnableToLocateEOCDR)));
+    data.resize(2 * 1024 * 1024, 0);
+    let mut reader = super::ShortReader::new(Cursor::new(data), 2048);
+    assert!(matches!(eocdr(&mut reader).await, Err(ZipError::UnableToLocateEOCDR)));
+    assert!(reader.bytes_read < 72 * 1024, "EOCD lookup read {} bytes", reader.bytes_read);
 }
 
 #[tokio::test]

--- a/src/tests/read/locator/mod.rs
+++ b/src/tests/read/locator/mod.rs
@@ -74,3 +74,90 @@ async fn locator_buffer_boundary_test() {
     assert!(eocdr.is_ok());
     assert_eq!(eocdr.unwrap(), 4);
 }
+
+#[tokio::test]
+async fn locator_accepts_long_nul_padding() {
+    use crate::base::read::{io::locator::eocdr, mem, seek};
+    use futures_lite::io::Cursor;
+
+    // Neither uv nor Malo has long-padding cases. Keep the existing archives intact and append
+    // only padding beyond the maximum EOCD/comment search window, including chunk boundaries.
+    let archives: &[&[u8]] = &[
+        include_bytes!("empty.zip"),
+        include_bytes!("empty-with-max-comment.zip"),
+        include_bytes!("empty-buffer-boundary.zip"),
+        include_bytes!("../malo/accept/store.zip"),
+        include_bytes!("../malo/accept/comment.zip"),
+    ];
+    for &archive in archives {
+        let expected = eocdr(Cursor::new(archive)).await.unwrap();
+        for padding in [65_557, 65_558, 67_606] {
+            let mut data = archive.to_vec();
+            data.resize(data.len() + padding, 0);
+            assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
+            seek::ZipFileReader::new(Cursor::new(&data)).await.unwrap();
+            mem::ZipFileReader::new(data).await.unwrap();
+        }
+    }
+}
+
+#[cfg(feature = "deflate")]
+#[tokio::test]
+async fn locator_accepts_long_nul_padding_after_zip64() {
+    use crate::base::read::{io::locator::eocdr, mem, seek};
+    use futures_lite::io::Cursor;
+
+    let mut data = include_bytes!("../malo/accept/zip64_eocd.zip").to_vec();
+    let expected = eocdr(Cursor::new(&data)).await.unwrap();
+    data.resize(data.len() + 131_072, 0);
+    assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
+    super::cd::read_streamed_archive(&data[..]).await.unwrap();
+    seek::ZipFileReader::new(Cursor::new(&data)).await.unwrap();
+    mem::ZipFileReader::new(data).await.unwrap();
+}
+
+#[tokio::test]
+async fn locator_accepts_long_nul_padding_with_short_reads() {
+    use crate::base::read::io::locator::eocdr;
+    use futures_lite::io::Cursor;
+
+    let mut data = include_bytes!("empty.zip").to_vec();
+    data.resize(data.len() + 65_558, 0);
+    let reader = super::ShortReader::new(Cursor::new(data), 3);
+    assert_eq!(eocdr(reader).await.unwrap(), 4);
+}
+
+#[tokio::test]
+async fn locator_rejects_all_zero_input() {
+    use crate::base::read::io::locator::eocdr;
+    use crate::error::ZipError;
+    use futures_lite::io::Cursor;
+
+    let mut data = include_bytes!("empty.zip").to_vec();
+    data.fill(0);
+    data.resize(65_558, 0);
+    assert!(matches!(eocdr(Cursor::new(data)).await, Err(ZipError::UnableToLocateEOCDR)));
+}
+
+#[tokio::test]
+async fn terminal_zero_fields_must_not_hide_truncation() {
+    use crate::base::read::seek::ZipFileReader;
+    use futures_lite::io::Cursor;
+
+    // The zero-filled EOCD fields are required bytes, not optional NUL padding.
+    let data = include_bytes!("empty.zip");
+    let error = ZipFileReader::new(Cursor::new(&data[..data.len() - 1])).await.err().unwrap();
+    super::assert_unexpected_eof(error);
+}
+
+#[tokio::test]
+async fn nonzero_contents_after_long_padding_are_rejected() {
+    use crate::base::read::seek::ZipFileReader;
+    use futures_lite::io::Cursor;
+
+    let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
+    data.resize(data.len() + 131_072, 0);
+    data.push(b'X');
+    assert!(ZipFileReader::new(Cursor::new(&data)).await.is_err());
+    assert!(super::cd::read_streamed_archive(&data[..]).await.is_err());
+}

--- a/src/tests/read/locator/mod.rs
+++ b/src/tests/read/locator/mod.rs
@@ -76,65 +76,20 @@ async fn locator_buffer_boundary_test() {
 }
 
 #[tokio::test]
-async fn locator_accepts_nul_padding_up_to_limit() {
-    use crate::base::read::{io::locator::eocdr, mem, seek};
-    use futures_lite::io::Cursor;
-
-    // Append only padding to existing fixtures, including chunk boundaries and the 4 KiB limit.
-    // A zero-filled maximum comment distinguishes declared comment bytes from suffix padding.
-    let mut nul_comment = include_bytes!("empty-with-max-comment.zip").to_vec();
-    nul_comment[22..].fill(0);
-    let archives: &[&[u8]] = &[
-        include_bytes!("empty.zip"),
-        include_bytes!("empty-with-max-comment.zip"),
-        &nul_comment,
-        include_bytes!("empty-buffer-boundary.zip"),
-        include_bytes!("../malo/accept/store.zip"),
-        include_bytes!("../malo/accept/comment.zip"),
-    ];
-    for &archive in archives {
-        let expected = eocdr(Cursor::new(archive)).await.unwrap();
-        for padding in [0, 2047, 2048, 2049, 4095, 4096] {
-            let mut data = archive.to_vec();
-            data.resize(data.len() + padding, 0);
-            assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
-            seek::ZipFileReader::new(Cursor::new(&data)).await.unwrap();
-            mem::ZipFileReader::new(data).await.unwrap();
-        }
-    }
-}
-
-#[cfg(feature = "deflate")]
-#[tokio::test]
-async fn zip64_nul_padding_limit_is_enforced() {
-    use crate::base::read::{io::locator::eocdr, mem, seek};
-    use futures_lite::io::Cursor;
-
-    let original = include_bytes!("../malo/accept/zip64_eocd.zip");
-    let expected = eocdr(Cursor::new(original)).await.unwrap();
-    for padding in [4096, 4097] {
-        let mut data = original.to_vec();
-        data.resize(data.len() + padding, 0);
-        assert_eq!(eocdr(Cursor::new(&data)).await.unwrap(), expected);
-        for result in [
-            super::cd::read_streamed_archive(&data[..]).await,
-            seek::ZipFileReader::new(Cursor::new(&data)).await.map(|_| ()),
-            mem::ZipFileReader::new(data).await.map(|_| ()),
-        ] {
-            assert_eq!(result.is_ok(), padding <= 4096, "{padding} padding bytes: {result:?}");
-        }
-    }
-}
-
-#[tokio::test]
 async fn locator_accepts_maximum_comment_and_padding_with_short_reads() {
-    use crate::base::read::io::locator::eocdr;
-    use futures_lite::io::Cursor;
+    use crate::base::read::seek::ZipFileReader;
+    use futures_lite::io::{BufReader, Cursor};
 
-    let mut data = include_bytes!("empty-with-max-comment.zip").to_vec();
-    data.resize(data.len() + 4096, 0);
-    let reader = super::ShortReader::new(Cursor::new(data), 3);
-    assert_eq!(eocdr(reader).await.unwrap(), 4);
+    for nul_comment in [false, true] {
+        let mut data = include_bytes!("empty-with-max-comment.zip").to_vec();
+        if nul_comment {
+            // Declared comment bytes must not count toward the padding limit, even if all NUL.
+            data[22..].fill(0);
+        }
+        data.resize(data.len() + 4096, 0);
+        let reader = BufReader::new(super::ShortReader::new(Cursor::new(data), 3));
+        ZipFileReader::new(reader).await.unwrap();
+    }
 }
 
 #[tokio::test]
@@ -149,27 +104,4 @@ async fn locator_rejects_all_zero_input() {
     let mut reader = super::ShortReader::new(Cursor::new(data), 2048);
     assert!(matches!(eocdr(&mut reader).await, Err(ZipError::UnableToLocateEOCDR)));
     assert!(reader.bytes_read < 72 * 1024, "EOCD lookup read {} bytes", reader.bytes_read);
-}
-
-#[tokio::test]
-async fn terminal_zero_fields_must_not_hide_truncation() {
-    use crate::base::read::seek::ZipFileReader;
-    use futures_lite::io::Cursor;
-
-    // The zero-filled EOCD fields are required bytes, not optional NUL padding.
-    let data = include_bytes!("empty.zip");
-    let error = ZipFileReader::new(Cursor::new(&data[..data.len() - 1])).await.err().unwrap();
-    super::assert_unexpected_eof(error);
-}
-
-#[tokio::test]
-async fn nonzero_contents_after_long_padding_are_rejected() {
-    use crate::base::read::seek::ZipFileReader;
-    use futures_lite::io::Cursor;
-
-    let mut data = include_bytes!("../malo/accept/store.zip").to_vec();
-    data.resize(data.len() + 131_072, 0);
-    data.push(b'X');
-    assert!(ZipFileReader::new(Cursor::new(&data)).await.is_err());
-    assert!(super::cd::read_streamed_archive(&data[..]).await.is_err());
 }

--- a/src/tests/read/mod.rs
+++ b/src/tests/read/mod.rs
@@ -23,11 +23,12 @@ struct ShortReader<R> {
     inner: R,
     max_read: usize,
     eof_error: Option<std::io::ErrorKind>,
+    bytes_read: usize,
 }
 
 impl<R> ShortReader<R> {
     fn new(inner: R, max_read: usize) -> Self {
-        Self { inner, max_read, eof_error: None }
+        Self { inner, max_read, eof_error: None, bytes_read: 0 }
     }
 
     fn with_eof_error(mut self, kind: std::io::ErrorKind) -> Self {
@@ -42,6 +43,10 @@ impl<R: AsyncRead + Unpin> AsyncRead for ShortReader<R> {
         match Pin::new(&mut self.inner).poll_read(cx, &mut buf[..max_read]) {
             Poll::Ready(Ok(0)) if !buf.is_empty() && self.eof_error.is_some() => {
                 Poll::Ready(Err(std::io::Error::new(self.eof_error.unwrap(), "suffix read failed")))
+            }
+            Poll::Ready(Ok(read)) => {
+                self.bytes_read += read;
+                Poll::Ready(Ok(read))
             }
             result => result,
         }

--- a/src/tests/read/mod.rs
+++ b/src/tests/read/mod.rs
@@ -67,18 +67,19 @@ fn assert_unexpected_eof(error: ZipError) {
 }
 
 #[tokio::test]
-async fn test_truncated_eocdr_comment_is_rejected() {
+async fn test_truncated_eocdr_is_rejected() {
     use futures_lite::io::Cursor;
 
     use crate::base::read::seek::ZipFileReader;
 
-    // The fixture ends one byte before its declared EOCD comment length.
-    let reader = Cursor::new(include_bytes!("truncated/empty-with-max-comment.zip"));
-    let Err(error) = ZipFileReader::new(reader).await else {
-        panic!("expected a truncated EOCD comment to fail");
-    };
-
-    assert_unexpected_eof(error);
+    // Neither declared comment bytes nor zero-filled EOCD fields are optional padding.
+    let empty = include_bytes!("locator/empty.zip");
+    for data in [include_bytes!("truncated/empty-with-max-comment.zip").as_slice(), &empty[..empty.len() - 1]] {
+        let Err(error) = ZipFileReader::new(Cursor::new(data)).await else {
+            panic!("expected a truncated EOCD to fail");
+        };
+        assert_unexpected_eof(error);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Cap NUL padding after the declared archive comment at 4 KiB. Enforce the limit in the shared suffix validator used by seeking, memory, filesystem, and streaming footer parsing, for both classic ZIP and ZIP64.

Bound backward EOCD lookup to the fixed end record, maximum comment length, and 4 KiB padding allowance. This replaces the unbounded backward NUL scan. Required zero-valued EOCD fields and declared comments retain their original offsets and do not count toward the padding cap. Builds on #62.

## Validation

- The consolidated suite still fails against the pre-cap implementation in its padding-limit test and both bounded-I/O tests.
- Reader suites pass: 68 tests without features and 84 with all features.
- Accepts 4,096 padding bytes and rejects 4,097. Reader instrumentation checks that suffix validation reads at most 4,097 bytes and EOCD lookup reads less than 72 KiB from a 2 MiB all-zero source.
- Reuses existing empty and maximum-comment fixtures plus Malo classic ZIP and ZIP64 controls. Derived cases append padding or zero-fill a declared maximum-length comment.
- Covers maximum-length comments plus maximum padding, short reads, legitimate terminal zeros, and truncated fields without repeating the full fixture/padding matrix through each constructor.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
